### PR TITLE
fix: correct github_repo documentation example format

### DIFF
--- a/praisonai_tools/tools/github_search_tool/README.md
+++ b/praisonai_tools/tools/github_search_tool/README.md
@@ -20,7 +20,7 @@ from praisonai_tools import GithubSearchTool
 # Initialize the tool for semantic searches within a specific GitHub repository
 tool = GithubSearchTool(
     gh_token='...',
-	github_repo='https://github.com/example/repo',
+	github_repo='example/repo',
 	content_types=['code', 'issue'] # Options: code, repo, pr, issue
 )
 


### PR DESCRIPTION
Fixed the incorrect documentation example for `GithubSearchTool`.

The example was showing a full GitHub URL (`https://github.com/example/repo`) when it should be in the `owner/repository` format (`example/repo`).

This change prevents the 422 validation error users were experiencing.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)