### PR TITLE
Add CapsuleTool for secure, sandboxed Python code execution.

### DIFF
--- a/praisonai_tools/tools/__init__.py
+++ b/praisonai_tools/tools/__init__.py
@@ -342,6 +342,9 @@ def __getattr__(name):
         # Python
         "PythonTool": "python_tool",
         "python_execute": "python_tool",
+        # Capsule
+        "CapsuleTool": "capsule_tool",
+        "capsule_run_code": "capsule_tool",
         # Mem0
         "Mem0Tool": "mem0_tool",
         "mem0_add": "mem0_tool",
@@ -413,13 +416,13 @@ def __getattr__(name):
         "check_wp_duplicate": "wordpress_tool",
         "create_wp_post": "wordpress_tool",
     }
-    
+
     if name in tool_map:
         module_name = tool_map[name]
         from importlib import import_module
         module = import_module(f".{module_name}", __package__)
         return getattr(module, name)
-    
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [

--- a/praisonai_tools/tools/capsule_tool.py
+++ b/praisonai_tools/tools/capsule_tool.py
@@ -1,0 +1,60 @@
+"""Capsule Tool for PraisonAI Agents.
+
+Run untrusted Python code in local WebAssembly sandboxes.
+
+Usage:
+    from praisonai_tools import CapsuleTool
+
+    capsule = CapsuleTool()
+    result = capsule.run_code("print('Hello from Python')")
+"""
+
+import logging
+from typing import Any, Dict, Optional, Union
+
+from praisonai_tools.tools.base import BaseTool
+
+logger = logging.getLogger(__name__)
+
+
+class CapsuleTool(BaseTool):
+    """Tool for sandboxed Python code execution."""
+
+    name = "capsule"
+    description: str = (
+        "Execute Python code in a secure isolated WebAssembly sandbox. "
+        "Both standard output (print statements) and the last evaluated expression are returned. "
+        "Supports pure Python code only."
+    )
+
+    def run(
+        self,
+        action: str = "run_code",
+        code: Optional[str] = None,
+        **kwargs
+    ) -> Union[str, Dict[str, Any]]:
+        if action == "run_code":
+            return self.run_code(code=code)
+        return {"error": f"Unknown action: {action}"}
+
+    def run_code(self, code: str) -> Dict[str, Any]:
+        """Run Python code in sandbox."""
+        if not code:
+            return {"error": "code is required"}
+
+        try:
+            from langchain_capsule import CapsulePythonTool
+        except ImportError:
+            return {"error": "langchain-capsule not installed. Install with: pip install langchain-capsule"}
+
+        try:
+            return CapsulePythonTool().run(code)
+        except Exception as e:
+            logger.error(f"Capsule Python execution error: {e}")
+            return {"error": str(e)}
+
+
+def capsule_run_code(code: str) -> Dict[str, Any]:
+    """Run code in Capsule."""
+    return CapsuleTool().run_code(code=code)
+

--- a/praisonai_tools/tools/capsule_tool.py
+++ b/praisonai_tools/tools/capsule_tool.py
@@ -9,12 +9,14 @@ Usage:
     result = capsule.run_code("print('Hello from Python')")
 """
 
+import asyncio
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from praisonai_tools.tools.base import BaseTool
 
 logger = logging.getLogger(__name__)
+_capsule_tool_instance = None
 
 
 class CapsuleTool(BaseTool):
@@ -32,29 +34,64 @@ class CapsuleTool(BaseTool):
         action: str = "run_code",
         code: Optional[str] = None,
         **kwargs
-    ) -> Union[str, Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         if action == "run_code":
             return self.run_code(code=code)
+        elif action == "preload":
+            return self.preload()
         return {"error": f"Unknown action: {action}"}
 
-    def run_code(self, code: str) -> Dict[str, Any]:
-        """Run Python code in sandbox."""
+    def run_code(self, code: Optional[str] = None) -> Dict[str, Any]:
+        """Run Python code in sandbox.
+
+        Args:
+            code: Python code to execute
+
+        Returns:
+            Dict with 'result' key (success) or 'error' key (failure)
+        """
         if not code:
             return {"error": "code is required"}
 
         try:
-            from langchain_capsule import CapsulePythonTool
+            from capsule_adapter import run_python
         except ImportError:
-            return {"error": "langchain-capsule not installed. Install with: pip install langchain-capsule"}
+            return {"error": "capsule_adapter not installed. Install with: pip install capsule-run-adapter"}
 
         try:
-            return CapsulePythonTool().run(code)
+            result = asyncio.run(run_python(code))
+            return {"result": result}
         except Exception as e:
             logger.error(f"Capsule Python execution error: {e}")
             return {"error": str(e)}
 
+    def preload(self) -> Dict[str, Any]:
+        """Preload Python sandbox for faster execution.
+
+        Returns:
+            Dict with 'status' and 'message' keys
+        """
+        try:
+            from capsule_adapter import load_python_sandbox
+        except ImportError:
+            return {"error": "capsule_adapter not installed. Install with: pip install capsule-run-adapter"}
+
+        try:
+            asyncio.run(load_python_sandbox())
+            return {"status": "success", "message": "Python sandbox preloaded successfully"}
+        except Exception as e:
+            logger.error(f"Capsule preload error: {e}")
+            return {"error": str(e)}
+
+
+def _get_capsule_tool() -> CapsuleTool:
+    """Get or create the singleton CapsuleTool instance."""
+    global _capsule_tool_instance
+    if _capsule_tool_instance is None:
+        _capsule_tool_instance = CapsuleTool()
+    return _capsule_tool_instance
+
 
 def capsule_run_code(code: str) -> Dict[str, Any]:
     """Run code in Capsule."""
-    return CapsuleTool().run_code(code=code)
-
+    return _get_capsule_tool().run_code(code=code)


### PR DESCRIPTION
## Capsule tool

Add `capsule_tool.py`,  a lightweight Wasm sandbox to safely run untrusted Python code in PraisonAI agents.

### Usage
```python
 from praisonai_tools import CapsuleTool
 
 tool = CapsuleTool()
 result = tool.run_code("print('Hello from Python')")
```

### Related issue
https://github.com/MervinPraison/PraisonAI/issues/1116