### PR TITLE
fix: Fix n8n integration test mocking issues

### DIFF
--- a/tests/test_n8n_integration.py
+++ b/tests/test_n8n_integration.py
@@ -10,10 +10,22 @@ class TestN8nWorkflowTool:
     
     @pytest.fixture
     def mock_httpx(self):
-        # Mock httpx in sys.modules to catch lazy imports
-        with patch.dict('sys.modules', {'httpx': MagicMock()}) as mock_modules:
-            mock_httpx = mock_modules['httpx']
-            yield mock_httpx
+        """Mock httpx module for testing."""
+        mock_module = MagicMock()
+        
+        # Create proper exception classes
+        mock_module.TimeoutException = type('TimeoutException', (Exception,), {})
+        
+        class MockHTTPStatusError(Exception):
+            def __init__(self, message, request=None, response=None):
+                super().__init__(message)
+                self.request = request
+                self.response = response
+        
+        mock_module.HTTPStatusError = MockHTTPStatusError
+        
+        with patch.dict('sys.modules', {'httpx': mock_module}) as mock_modules:
+            yield mock_module
     
     def test_import_n8n_tools(self):
         """Test that n8n tools can be imported."""
@@ -69,7 +81,8 @@ class TestN8nWorkflowTool:
         from praisonai_tools.n8n import N8nWorkflowTool
         
         tool = N8nWorkflowTool()
-        with patch('praisonai_tools.n8n.n8n_workflow.httpx', None):
+        # Mock the import failure using sys.modules approach
+        with patch.dict('sys.modules', {'httpx': None}):
             with patch('builtins.__import__', side_effect=ImportError("No module named 'httpx'")):
                 result = tool.run(workflow_id="test-workflow")
                 assert "httpx not installed" in result["error"]


### PR DESCRIPTION
Fixes #20

This PR fixes the test mocking issues in the n8n integration that were causing 2 test failures.

## Changes
- Fixed `test_n8n_workflow_missing_httpx` to use `sys.modules` approach for lazy import mocking
- Enhanced `mock_httpx` fixture with proper HTTPStatusError and TimeoutException classes
- All 14 tests now pass (12 passed, 2 integration tests correctly skipped)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture infrastructure to better simulate missing dependency conditions and exception scenarios.
  * Refined test methodology for validating error handling when required external libraries are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->