### PR TITLE
feat: implement langextract tools for interactive text visualization

### DIFF
--- a/contract-001.html
+++ b/contract-001.html
@@ -1,0 +1,1 @@
+<html>mock visualization</html>

--- a/examples/langextract_example.py
+++ b/examples/langextract_example.py
@@ -1,0 +1,275 @@
+"""
+Langextract Tool Example
+
+This example demonstrates how to use the langextract tools for 
+interactive text visualization and analysis with PraisonAI agents.
+
+Prerequisites:
+    pip install praisonai-tools[langextract]
+    # or 
+    pip install praisonai-tools langextract
+
+Features demonstrated:
+- Text analysis with highlighted extractions
+- File-based document analysis  
+- Integration with PraisonAI agents
+- Interactive HTML generation
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from praisonai_tools import langextract_extract, langextract_render_file
+
+
+def basic_text_analysis():
+    """Demonstrate basic text analysis with highlighted extractions."""
+    print("🔍 Basic Text Analysis with Langextract")
+    print("=" * 50)
+    
+    # Sample contract text
+    contract_text = """
+    CONSULTING AGREEMENT
+    
+    This Agreement is entered into on March 15, 2024, between TechCorp Inc. 
+    (the "Client") and Jane Smith (the "Consultant"). The Consultant will 
+    provide AI development services for a period of 6 months starting 
+    April 1, 2024. 
+    
+    Payment terms: $5,000 per month, payable within 15 days of invoice date.
+    Confidentiality obligations remain in effect for 2 years after termination.
+    """
+    
+    # Key terms to highlight
+    key_terms = [
+        "TechCorp Inc.",
+        "Jane Smith", 
+        "March 15, 2024",
+        "April 1, 2024",
+        "$5,000 per month",
+        "15 days",
+        "2 years",
+        "AI development services"
+    ]
+    
+    # Extract and visualize
+    result = langextract_extract(
+        text=contract_text,
+        extractions=key_terms,
+        document_id="consulting-agreement",
+        output_path="contract_analysis.html",
+        auto_open=False  # Set to True to open in browser automatically
+    )
+    
+    if result.get("success"):
+        print(f"✅ Analysis complete!")
+        print(f"   Document ID: {result['document_id']}")
+        print(f"   Output file: {result['output_path']}")
+        print(f"   Extractions: {result['extractions_count']} terms highlighted")
+        print(f"   Text length: {result['text_length']} characters")
+        print()
+        print(f"💡 Open {result['output_path']} in your browser to view the interactive visualization!")
+    else:
+        print(f"❌ Error: {result.get('error')}")
+        if "langextract not installed" in result.get("error", ""):
+            print("💡 Install with: pip install langextract")
+
+
+def file_analysis_example():
+    """Demonstrate file-based document analysis."""
+    print("📄 File-based Document Analysis")
+    print("=" * 50)
+    
+    # Create a sample document
+    document_content = """
+    TECHNICAL SPECIFICATION DOCUMENT
+    
+    Project: AI-Powered Analytics Dashboard
+    Version: 2.1.0
+    Date: April 17, 2026
+    
+    REQUIREMENTS:
+    - Python 3.10+ runtime environment
+    - PostgreSQL 14+ database
+    - Redis for caching layer
+    - Docker for containerization
+    - Kubernetes for orchestration
+    
+    SECURITY CONSIDERATIONS:
+    - JWT authentication with 24-hour expiry
+    - Rate limiting: 1000 requests per hour per API key
+    - HTTPS-only communication
+    - Data encryption at rest using AES-256
+    
+    PERFORMANCE TARGETS:
+    - API response time: < 200ms for 95th percentile
+    - Database query optimization required
+    - Concurrent user support: 10,000+ users
+    """
+    
+    # Create temporary file
+    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as f:
+        f.write(document_content)
+        temp_file_path = f.name
+    
+    try:
+        # Technical terms to highlight
+        tech_terms = [
+            "Python 3.10+",
+            "PostgreSQL 14+", 
+            "Redis",
+            "Docker",
+            "Kubernetes",
+            "JWT authentication",
+            "24-hour expiry",
+            "1000 requests per hour",
+            "AES-256",
+            "< 200ms",
+            "10,000+ users"
+        ]
+        
+        # Analyze the file
+        result = langextract_render_file(
+            file_path=temp_file_path,
+            extractions=tech_terms,
+            output_path="tech_spec_analysis.html",
+            auto_open=False
+        )
+        
+        if result.get("success"):
+            print(f"✅ File analysis complete!")
+            print(f"   Source file: {temp_file_path}")
+            print(f"   Document ID: {result['document_id']}")
+            print(f"   Output file: {result['output_path']}")
+            print(f"   Extractions: {result['extractions_count']} terms highlighted")
+            print(f"   Text length: {result['text_length']} characters")
+            print()
+            print(f"💡 Open {result['output_path']} in your browser to view the interactive visualization!")
+        else:
+            print(f"❌ Error: {result.get('error')}")
+    
+    finally:
+        # Clean up temporary file
+        try:
+            os.unlink(temp_file_path)
+        except OSError:
+            pass
+
+
+def agent_integration_example():
+    """Demonstrate integration with PraisonAI agents."""
+    print("🤖 PraisonAI Agent Integration")
+    print("=" * 50)
+    
+    # This is how you would integrate with agents
+    agent_code = '''
+from praisonaiagents import Agent
+from praisonai_tools import langextract_extract, langextract_render_file
+
+# Create an agent that analyzes documents
+document_analyzer = Agent(
+    name="DocumentAnalyzer",
+    instructions="""
+    You are a document analysis expert. When given text or documents,
+    identify key entities, dates, financial figures, and important terms.
+    Use langextract tools to create interactive visualizations highlighting
+    your findings.
+    """,
+    tools=[langextract_extract, langextract_render_file]
+)
+
+# Agent workflow example
+def analyze_document(text_or_file_path):
+    """Agent analyzes document and creates visualization."""
+    
+    if text_or_file_path.endswith('.txt'):
+        # File-based analysis
+        response = document_analyzer.start(
+            f"Analyze this document file and highlight key terms: {text_or_file_path}"
+        )
+    else:
+        # Text-based analysis
+        response = document_analyzer.start(
+            f"Analyze this text and highlight important information: {text_or_file_path}"
+        )
+    
+    return response
+
+# Example usage:
+# result = analyze_document("contract.txt")
+# result = analyze_document("The quarterly report shows revenue of $1.2M...")
+'''
+    
+    print("💻 Example agent integration code:")
+    print(agent_code)
+    print()
+    print("🔧 Key integration points:")
+    print("   - Import tools: langextract_extract, langextract_render_file")
+    print("   - Add to agent tools list")
+    print("   - Agent can automatically use tools based on instructions")
+    print("   - Interactive HTML files created for human review")
+
+
+def error_handling_example():
+    """Demonstrate graceful error handling."""
+    print("⚠️  Error Handling and Graceful Degradation")
+    print("=" * 50)
+    
+    # Test without langextract installed (simulated)
+    print("Testing graceful degradation when langextract is not installed:")
+    
+    result = langextract_extract(
+        text="Sample text for analysis",
+        extractions=["Sample"],
+        document_id="test"
+    )
+    
+    if "error" in result:
+        print(f"✅ Graceful error handling: {result['error']}")
+        print("💡 Users get clear installation instructions")
+    else:
+        print("✅ Langextract is available and working!")
+    
+    print()
+    print("Common error scenarios handled:")
+    print("   - ❌ langextract not installed → Clear installation message")
+    print("   - ❌ Invalid file path → File not found error") 
+    print("   - ❌ Empty text input → Parameter validation")
+    print("   - ❌ Browser auto-open fails → Graceful fallback")
+
+
+def main():
+    """Run all examples."""
+    print("🚀 Langextract Tool Examples for PraisonAI")
+    print("=" * 70)
+    print()
+    
+    try:
+        basic_text_analysis()
+        print()
+        
+        file_analysis_example()  
+        print()
+        
+        agent_integration_example()
+        print()
+        
+        error_handling_example()
+        print()
+        
+        print("🎉 All examples completed!")
+        print()
+        print("📚 Next Steps:")
+        print("   1. Install langextract: pip install langextract")
+        print("   2. Run your own text analysis")
+        print("   3. Integrate with your PraisonAI agents")
+        print("   4. Open generated HTML files to see interactive visualizations")
+        
+    except Exception as e:
+        print(f"❌ Example error: {e}")
+        print("💡 This is expected if langextract is not installed")
+
+
+if __name__ == "__main__":
+    main()

--- a/financial-analysis.html
+++ b/financial-analysis.html
@@ -1,0 +1,189 @@
+<style>
+.lx-highlight { position: relative; border-radius:3px; padding:1px 2px;}
+.lx-highlight .lx-tooltip {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  background: #333;
+  color: #fff;
+  text-align: left;
+  border-radius: 4px;
+  padding: 6px 8px;
+  position: absolute;
+  z-index: 1000;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  max-width: 240px;
+  white-space: normal;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+.lx-highlight:hover .lx-tooltip { visibility: visible; opacity:1; }
+.lx-animated-wrapper { max-width: 100%; font-family: Arial, sans-serif; }
+.lx-controls {
+  background: #fafafa; border: 1px solid #90caf9; border-radius: 8px;
+  padding: 12px; margin-bottom: 16px;
+}
+.lx-button-row {
+  display: flex; justify-content: center; gap: 8px; margin-bottom: 12px;
+}
+.lx-control-btn {
+  background: #4285f4; color: white; border: none; border-radius: 4px;
+  padding: 8px 16px; cursor: pointer; font-size: 13px; font-weight: 500;
+  transition: background-color 0.2s;
+}
+.lx-control-btn:hover { background: #3367d6; }
+.lx-progress-container {
+  margin-bottom: 8px;
+}
+.lx-progress-slider {
+  width: 100%; margin: 0; appearance: none; height: 6px;
+  background: #ddd; border-radius: 3px; outline: none;
+}
+.lx-progress-slider::-webkit-slider-thumb {
+  appearance: none; width: 18px; height: 18px; background: #4285f4;
+  border-radius: 50%; cursor: pointer;
+}
+.lx-progress-slider::-moz-range-thumb {
+  width: 18px; height: 18px; background: #4285f4; border-radius: 50%;
+  cursor: pointer; border: none;
+}
+.lx-status-text {
+  text-align: center; font-size: 12px; color: #666; margin-top: 4px;
+}
+.lx-text-window {
+  font-family: monospace; white-space: pre-wrap; border: 1px solid #90caf9;
+  padding: 12px; max-height: 260px; overflow-y: auto; margin-bottom: 12px;
+  line-height: 1.6;
+}
+.lx-attributes-panel {
+  background: #fafafa; border: 1px solid #90caf9; border-radius: 6px;
+  padding: 8px 10px; margin-top: 8px; font-size: 13px;
+}
+.lx-current-highlight {
+  border-bottom: 4px solid #ff4444;
+  font-weight: bold;
+  animation: lx-pulse 1s ease-in-out;
+}
+@keyframes lx-pulse {
+  0% { text-decoration-color: #ff4444; }
+  50% { text-decoration-color: #ff0000; }
+  100% { text-decoration-color: #ff4444; }
+}
+.lx-legend {
+  font-size: 12px; margin-bottom: 8px;
+  padding-bottom: 8px; border-bottom: 1px solid #e0e0e0;
+}
+.lx-label {
+  display: inline-block;
+  padding: 2px 4px;
+  border-radius: 3px;
+  margin-right: 4px;
+  color: #000;
+}
+.lx-attr-key {
+  font-weight: 600;
+  color: #1565c0;
+  letter-spacing: 0.3px;
+}
+.lx-attr-value {
+  font-weight: 400;
+  opacity: 0.85;
+  letter-spacing: 0.2px;
+}
+
+/* Add optimizations with larger fonts and better readability for GIFs */
+.lx-gif-optimized .lx-text-window { font-size: 16px; line-height: 1.8; }
+.lx-gif-optimized .lx-attributes-panel { font-size: 15px; }
+.lx-gif-optimized .lx-current-highlight { text-decoration-thickness: 4px; }
+</style>
+<div class="lx-animated-wrapper lx-gif-optimized">
+  <div class="lx-attributes-panel">
+    <div class="lx-legend">Highlights Legend: <span class="lx-label" style="background-color:#D2E3FC;">extraction_0</span> <span class="lx-label" style="background-color:#C8E6C9;">extraction_1</span> <span class="lx-label" style="background-color:#FEF0C3;">extraction_2</span></div>
+    <div id="attributesContainer"></div>
+  </div>
+  <div class="lx-text-window" id="textWindow">
+    The <span class="lx-highlight lx-current-highlight" data-idx="0" style="background-color:#FEF0C3;">quarterly report</span> shows revenue of <span class="lx-highlight" data-idx="1" style="background-color:#D2E3FC;">$1.2M</span> and profit of <span class="lx-highlight" data-idx="2" style="background-color:#C8E6C9;">$300K</span>.
+  </div>
+  <div class="lx-controls">
+    <div class="lx-button-row">
+      <button class="lx-control-btn" onclick="playPause()">▶️ Play</button>
+      <button class="lx-control-btn" onclick="prevExtraction()">⏮ Previous</button>
+      <button class="lx-control-btn" onclick="nextExtraction()">⏭ Next</button>
+    </div>
+    <div class="lx-progress-container">
+      <input type="range" id="progressSlider" class="lx-progress-slider"
+             min="0" max="2" value="0"
+             onchange="jumpToExtraction(this.value)">
+    </div>
+    <div class="lx-status-text">
+      Entity <span id="entityInfo">1/3</span> |
+      Pos <span id="posInfo">[38-43]</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function() {
+    const extractions = [{"index": 0, "class": "extraction_2", "text": "quarterly report", "color": "#FEF0C3", "startPos": 4, "endPos": 20, "beforeText": "The ", "extractionText": "quarterly report", "afterText": " shows revenue of $1.2M and profit of $300K.", "attributesHtml": "<div><strong>class:</strong> extraction_2</div><div><strong>attributes:</strong> {<span class=\"lx-attr-key\">index</span>: <span class=\"lx-attr-value\">2</span>, <span class=\"lx-attr-key\">original_text</span>: <span class=\"lx-attr-value\">quarterly report</span>, <span class=\"lx-attr-key\">tool</span>: <span class=\"lx-attr-value\">langextract_extract</span>}</div>"}, {"index": 1, "class": "extraction_0", "text": "$1.2M", "color": "#D2E3FC", "startPos": 38, "endPos": 43, "beforeText": "The quarterly report shows revenue of ", "extractionText": "$1.2M", "afterText": " and profit of $300K.", "attributesHtml": "<div><strong>class:</strong> extraction_0</div><div><strong>attributes:</strong> {<span class=\"lx-attr-key\">index</span>: <span class=\"lx-attr-value\">0</span>, <span class=\"lx-attr-key\">original_text</span>: <span class=\"lx-attr-value\">$1.2M</span>, <span class=\"lx-attr-key\">tool</span>: <span class=\"lx-attr-value\">langextract_extract</span>}</div>"}, {"index": 2, "class": "extraction_1", "text": "$300K", "color": "#C8E6C9", "startPos": 58, "endPos": 63, "beforeText": "The quarterly report shows revenue of $1.2M and profit of ", "extractionText": "$300K", "afterText": ".", "attributesHtml": "<div><strong>class:</strong> extraction_1</div><div><strong>attributes:</strong> {<span class=\"lx-attr-key\">index</span>: <span class=\"lx-attr-value\">1</span>, <span class=\"lx-attr-key\">original_text</span>: <span class=\"lx-attr-value\">$300K</span>, <span class=\"lx-attr-key\">tool</span>: <span class=\"lx-attr-value\">langextract_extract</span>}</div>"}];
+    let currentIndex = 0;
+    let isPlaying = false;
+    let animationInterval = null;
+    let animationSpeed = 1.0;
+
+    function updateDisplay() {
+      const extraction = extractions[currentIndex];
+      if (!extraction) return;
+
+      document.getElementById('attributesContainer').innerHTML = extraction.attributesHtml;
+      document.getElementById('entityInfo').textContent = (currentIndex + 1) + '/' + extractions.length;
+      document.getElementById('posInfo').textContent = '[' + extraction.startPos + '-' + extraction.endPos + ']';
+      document.getElementById('progressSlider').value = currentIndex;
+
+      const playBtn = document.querySelector('.lx-control-btn');
+      if (playBtn) playBtn.textContent = isPlaying ? '⏸ Pause' : '▶️ Play';
+
+      const prevHighlight = document.querySelector('.lx-text-window .lx-current-highlight');
+      if (prevHighlight) prevHighlight.classList.remove('lx-current-highlight');
+      const currentSpan = document.querySelector('.lx-text-window span[data-idx="' + currentIndex + '"]');
+      if (currentSpan) {
+        currentSpan.classList.add('lx-current-highlight');
+        currentSpan.scrollIntoView({block: 'center', behavior: 'smooth'});
+      }
+    }
+
+    function nextExtraction() {
+      currentIndex = (currentIndex + 1) % extractions.length;
+      updateDisplay();
+    }
+
+    function prevExtraction() {
+      currentIndex = (currentIndex - 1 + extractions.length) % extractions.length;
+      updateDisplay();
+    }
+
+    function jumpToExtraction(index) {
+      currentIndex = parseInt(index);
+      updateDisplay();
+    }
+
+    function playPause() {
+      if (isPlaying) {
+        clearInterval(animationInterval);
+        isPlaying = false;
+      } else {
+        animationInterval = setInterval(nextExtraction, animationSpeed * 1000);
+        isPlaying = true;
+      }
+      updateDisplay();
+    }
+
+    window.playPause = playPause;
+    window.nextExtraction = nextExtraction;
+    window.prevExtraction = prevExtraction;
+    window.jumpToExtraction = jumpToExtraction;
+
+    updateDisplay();
+  })();
+</script>

--- a/praisonai_tools/tools/__init__.py
+++ b/praisonai_tools/tools/__init__.py
@@ -394,6 +394,10 @@ def __getattr__(name):
         # LumaLabs
         "LumaLabsTool": "lumalabs_tool",
         "lumalabs_generate": "lumalabs_tool",
+        # Langextract
+        "LangExtractTool": "langextract_tool",
+        "langextract_extract": "langextract_tool",
+        "langextract_render_file": "langextract_tool",
 # HeyGen
         "HeyGenTool": "heygen_tool",
         "heygen_list_avatars": "heygen_tool",
@@ -874,4 +878,8 @@ __all__ = [
     "N8nWorkflowTool",
     "n8n_workflow",
     "n8n_list_workflows",
+    # Langextract Tool
+    "LangExtractTool",
+    "langextract_extract",
+    "langextract_render_file",
 ]

--- a/praisonai_tools/tools/langextract_tool.py
+++ b/praisonai_tools/tools/langextract_tool.py
@@ -46,30 +46,40 @@ def _get_langextract():
 
 
 def _create_annotated_document(text: str, extractions: List[str], document_id: str):
-    """Create langextract AnnotatedDocument with extractions as CharIntervals."""
+    """Create langextract AnnotatedDocument with extractions as Extraction objects."""
     lx = _get_langextract()
     if not lx:
         return None
-    
-    # Find all extraction positions in the text
-    intervals = []
-    for extraction in extractions:
+
+    # Find all extraction positions and wrap as Extraction objects
+    extraction_objects = []
+    for i, extraction_text in enumerate(extractions or []):
+        if not extraction_text.strip():
+            continue
         start_pos = 0
         while True:
-            pos = text.find(extraction, start_pos)
+            pos = text.lower().find(extraction_text.lower(), start_pos)
             if pos == -1:
                 break
-            intervals.append(lx.data.CharInterval(
-                start_pos=pos,
-                end_pos=pos + len(extraction)
+            extraction_objects.append(lx.data.Extraction(
+                extraction_class=f"extraction_{i}",
+                extraction_text=extraction_text,
+                char_interval=lx.data.CharInterval(
+                    start_pos=pos,
+                    end_pos=pos + len(extraction_text),
+                ),
+                attributes={
+                    "index": i,
+                    "original_text": extraction_text,
+                    "tool": "langextract_extract",
+                },
             ))
             start_pos = pos + 1
-    
-    # Create annotated document
+
     return lx.data.AnnotatedDocument(
         document_id=document_id,
         text=text,
-        intervals=intervals
+        extractions=extraction_objects,
     )
 
 

--- a/praisonai_tools/tools/langextract_tool.py
+++ b/praisonai_tools/tools/langextract_tool.py
@@ -67,7 +67,7 @@ def _create_annotated_document(text: str, extractions: List[str], document_id: s
     
     # Create annotated document
     return lx.data.AnnotatedDocument(
-        id=document_id,
+        document_id=document_id,
         text=text,
         intervals=intervals
     )

--- a/praisonai_tools/tools/langextract_tool.py
+++ b/praisonai_tools/tools/langextract_tool.py
@@ -1,0 +1,271 @@
+"""Langextract Tool for PraisonAI Agents.
+
+Interactive text visualization and annotation with highlighted extractions.
+
+Usage:
+    from praisonai_tools import langextract_extract, langextract_render_file
+    
+    # Extract from text
+    result = langextract_extract(
+        text="John Doe works at OpenAI",
+        extractions=["John Doe", "OpenAI"],
+        document_id="contract-analysis"
+    )
+    
+    # Extract from file
+    result = langextract_render_file(
+        file_path="/path/to/document.txt",
+        extractions=["important terms"],
+        auto_open=True
+    )
+
+Installation:
+    pip install praisonai-tools[langextract]
+    # or
+    pip install praisonai-tools langextract
+"""
+
+import os
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from praisonai_tools.tools.base import BaseTool
+from praisonai_tools.tools.decorator import tool
+
+logger = logging.getLogger(__name__)
+
+
+def _get_langextract():
+    """Lazy import of langextract with helpful error message."""
+    try:
+        import langextract as lx
+        return lx
+    except ImportError:
+        return None
+
+
+def _create_annotated_document(text: str, extractions: List[str], document_id: str):
+    """Create langextract AnnotatedDocument with extractions as CharIntervals."""
+    lx = _get_langextract()
+    if not lx:
+        return None
+    
+    # Find all extraction positions in the text
+    intervals = []
+    for extraction in extractions:
+        start_pos = 0
+        while True:
+            pos = text.find(extraction, start_pos)
+            if pos == -1:
+                break
+            intervals.append(lx.data.CharInterval(
+                start_pos=pos,
+                end_pos=pos + len(extraction)
+            ))
+            start_pos = pos + 1
+    
+    # Create annotated document
+    return lx.data.AnnotatedDocument(
+        id=document_id,
+        text=text,
+        intervals=intervals
+    )
+
+
+class LangExtractTool(BaseTool):
+    """Tool for interactive text visualization with langextract."""
+    
+    name = "langextract"
+    description = "Create interactive HTML visualizations from text with highlighted extractions."
+    
+    def run(
+        self,
+        action: str = "extract",
+        text: Optional[str] = None,
+        file_path: Optional[str] = None,
+        extractions: Optional[List[str]] = None,
+        document_id: str = "agent-analysis",
+        output_path: Optional[str] = None,
+        auto_open: bool = False,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Run langextract action."""
+        if action == "extract":
+            return self.extract(
+                text=text,
+                extractions=extractions,
+                document_id=document_id,
+                output_path=output_path,
+                auto_open=auto_open
+            )
+        elif action == "render_file":
+            return self.render_file(
+                file_path=file_path,
+                extractions=extractions,
+                output_path=output_path,
+                auto_open=auto_open
+            )
+        return {"error": f"Unknown action: {action}"}
+    
+    def extract(
+        self,
+        text: str,
+        extractions: Optional[List[str]] = None,
+        document_id: str = "agent-analysis",
+        output_path: Optional[str] = None,
+        auto_open: bool = False
+    ) -> Dict[str, Any]:
+        """Extract and annotate text using langextract for interactive visualization."""
+        if not text:
+            return {"error": "text parameter is required"}
+        
+        lx = _get_langextract()
+        if not lx:
+            return {
+                "error": "langextract not installed. Install with: pip install langextract"
+            }
+        
+        try:
+            # Use provided extractions or empty list
+            extractions = extractions or []
+            
+            # Create annotated document
+            doc = _create_annotated_document(text, extractions, document_id)
+            if not doc:
+                return {"error": "Failed to create annotated document"}
+            
+            # Determine output path
+            if not output_path:
+                output_path = f"{document_id}.html"
+            
+            output_path = Path(output_path).resolve()
+            
+            # Save annotated documents and visualize
+            lx.io.save_annotated_documents([doc], str(output_path.parent / f"{document_id}.jsonl"))
+            lx.visualize(str(output_path))
+            
+            result = {
+                "success": True,
+                "document_id": document_id,
+                "output_path": str(output_path),
+                "extractions_count": len(extractions),
+                "text_length": len(text)
+            }
+            
+            # Auto-open in browser if requested
+            if auto_open:
+                try:
+                    import webbrowser
+                    file_uri = output_path.as_uri()
+                    webbrowser.open(file_uri)
+                    result["auto_opened"] = file_uri
+                except Exception as e:
+                    result["auto_open_error"] = str(e)
+            
+            return result
+            
+        except Exception as e:
+            logger.error(f"Langextract extract error: {e}")
+            return {"error": str(e)}
+    
+    def render_file(
+        self,
+        file_path: str,
+        extractions: Optional[List[str]] = None,
+        output_path: Optional[str] = None,
+        auto_open: bool = False
+    ) -> Dict[str, Any]:
+        """Read a text file and create langextract visualization."""
+        if not file_path:
+            return {"error": "file_path parameter is required"}
+        
+        try:
+            file_path = Path(file_path)
+            if not file_path.exists():
+                return {"error": f"File not found: {file_path}"}
+            
+            # Read file content
+            try:
+                text = file_path.read_text(encoding='utf-8')
+            except UnicodeDecodeError:
+                # Try with different encoding
+                text = file_path.read_text(encoding='latin1')
+            
+            # Generate document ID from filename
+            document_id = file_path.stem
+            
+            # Use extract method with file content
+            return self.extract(
+                text=text,
+                extractions=extractions,
+                document_id=document_id,
+                output_path=output_path,
+                auto_open=auto_open
+            )
+            
+        except Exception as e:
+            logger.error(f"Langextract render_file error: {e}")
+            return {"error": str(e)}
+
+
+@tool
+def langextract_extract(
+    text: str,
+    extractions: Optional[List[str]] = None,
+    document_id: str = "agent-analysis",
+    output_path: Optional[str] = None,
+    auto_open: bool = False
+) -> Dict[str, Any]:
+    """Extract and annotate text using langextract for interactive visualization.
+    
+    Creates an interactive HTML document with highlighted extractions that can be
+    viewed in a browser. Useful for text analysis, entity extraction, and 
+    document annotation workflows.
+    
+    Args:
+        text: The text content to analyze and annotate
+        extractions: List of text spans to highlight (optional)
+        document_id: Unique identifier for the document (default: "agent-analysis")
+        output_path: Where to save the HTML file (optional, auto-generated if not provided)
+        auto_open: Whether to automatically open the result in a browser (default: False)
+    
+    Returns:
+        Dictionary with success status, file paths, and extraction statistics
+    """
+    return LangExtractTool().extract(
+        text=text,
+        extractions=extractions,
+        document_id=document_id,
+        output_path=output_path,
+        auto_open=auto_open
+    )
+
+
+@tool
+def langextract_render_file(
+    file_path: str,
+    extractions: Optional[List[str]] = None,
+    output_path: Optional[str] = None,
+    auto_open: bool = False
+) -> Dict[str, Any]:
+    """Read a text file and create langextract visualization.
+    
+    WARNING: This tool can read arbitrary files from the filesystem.
+    Use with caution and ensure file_path is trusted.
+    
+    Args:
+        file_path: Path to the text file to analyze
+        extractions: List of text spans to highlight (optional)
+        output_path: Where to save the HTML file (optional, auto-generated if not provided)
+        auto_open: Whether to automatically open the result in a browser (default: False)
+    
+    Returns:
+        Dictionary with success status, file paths, and extraction statistics
+    """
+    return LangExtractTool().render_file(
+        file_path=file_path,
+        extractions=extractions,
+        output_path=output_path,
+        auto_open=auto_open
+    )

--- a/praisonai_tools/tools/langextract_tool.py
+++ b/praisonai_tools/tools/langextract_tool.py
@@ -151,9 +151,26 @@ class LangExtractTool(BaseTool):
             
             output_path = Path(output_path).resolve()
             
-            # Save annotated documents and visualize
-            lx.io.save_annotated_documents([doc], str(output_path.parent / f"{document_id}.jsonl"))
-            lx.visualize(str(output_path))
+            # Save JSONL and generate HTML from it
+            import tempfile, os
+            jsonl_dir = tempfile.gettempdir()
+            jsonl_path = os.path.join(jsonl_dir, f"{document_id}.jsonl")
+            lx.io.save_annotated_documents(
+                [doc],
+                output_name=os.path.basename(jsonl_path),
+                output_dir=jsonl_dir,
+            )
+
+            html = lx.visualize(jsonl_path)
+            html_content = html.data if hasattr(html, "data") else html
+
+            output_path = Path(output_path).resolve() if output_path else Path(f"{document_id}.html").resolve()
+            output_path.write_text(html_content, encoding="utf-8")
+
+            try:
+                os.remove(jsonl_path)
+            except OSError:
+                pass
             
             result = {
                 "success": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ agentfolio = [
 n8n = [
     "httpx>=0.27.0",
 ]
+langextract = [
+    "langextract>=0.1.0",
+]
 
 [project.urls]
 Homepage = "https://docs.praison.ai"

--- a/tests/test_langextract_tool.py
+++ b/tests/test_langextract_tool.py
@@ -1,0 +1,299 @@
+"""Tests for LangExtract Tool."""
+
+import pytest
+import tempfile
+import os
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+from praisonai_tools.tools.langextract_tool import (
+    LangExtractTool,
+    langextract_extract,
+    langextract_render_file,
+    _get_langextract,
+    _create_annotated_document
+)
+
+
+class TestLangExtractTool:
+    """Test LangExtractTool class."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.tool = LangExtractTool()
+    
+    def test_tool_properties(self):
+        """Test tool name and description."""
+        assert self.tool.name == "langextract"
+        assert "interactive HTML visualizations" in self.tool.description
+    
+    def test_run_unknown_action(self):
+        """Test run with unknown action."""
+        result = self.tool.run(action="unknown")
+        assert "error" in result
+        assert "Unknown action" in result["error"]
+    
+    def test_extract_without_langextract(self):
+        """Test extract when langextract is not installed."""
+        with patch('praisonai_tools.tools.langextract_tool._get_langextract', return_value=None):
+            result = self.tool.extract(text="test text")
+            assert "error" in result
+            assert "langextract not installed" in result["error"]
+    
+    def test_extract_empty_text(self):
+        """Test extract with empty text."""
+        result = self.tool.extract(text="")
+        assert "error" in result
+        assert "text parameter is required" in result["error"]
+    
+    @patch('praisonai_tools.tools.langextract_tool._get_langextract')
+    @patch('praisonai_tools.tools.langextract_tool._create_annotated_document')
+    def test_extract_success(self, mock_create_doc, mock_get_lx):
+        """Test successful text extraction."""
+        # Mock langextract
+        mock_lx = Mock()
+        mock_get_lx.return_value = mock_lx
+        
+        # Mock annotated document
+        mock_doc = Mock()
+        mock_create_doc.return_value = mock_doc
+        
+        # Mock visualization methods
+        mock_lx.io.save_annotated_documents = Mock()
+        mock_lx.visualize = Mock()
+        
+        text = "John Doe works at OpenAI"
+        extractions = ["John Doe", "OpenAI"]
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "test.html")
+            
+            result = self.tool.extract(
+                text=text,
+                extractions=extractions,
+                document_id="test-doc",
+                output_path=output_path
+            )
+            
+            assert result["success"] is True
+            assert result["document_id"] == "test-doc"
+            assert result["extractions_count"] == 2
+            assert result["text_length"] == len(text)
+            
+            # Verify langextract was called
+            mock_create_doc.assert_called_once_with(text, extractions, "test-doc")
+            mock_lx.io.save_annotated_documents.assert_called_once()
+            mock_lx.visualize.assert_called_once()
+    
+    @patch('praisonai_tools.tools.langextract_tool._get_langextract')
+    def test_extract_with_auto_open(self, mock_get_lx):
+        """Test extract with auto_open=True."""
+        # Mock langextract
+        mock_lx = Mock()
+        mock_get_lx.return_value = mock_lx
+        
+        # Mock document creation and visualization
+        with patch('praisonai_tools.tools.langextract_tool._create_annotated_document') as mock_create_doc:
+            mock_create_doc.return_value = Mock()
+            mock_lx.io.save_annotated_documents = Mock()
+            mock_lx.visualize = Mock()
+            
+            with patch('webbrowser.open') as mock_open:
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    output_path = os.path.join(temp_dir, "test.html")
+                    
+                    result = self.tool.extract(
+                        text="test text",
+                        auto_open=True,
+                        output_path=output_path
+                    )
+                    
+                    assert result["success"] is True
+                    assert "auto_opened" in result
+                    mock_open.assert_called_once()
+    
+    def test_render_file_missing_path(self):
+        """Test render_file with missing file_path."""
+        result = self.tool.render_file(file_path="")
+        assert "error" in result
+        assert "file_path parameter is required" in result["error"]
+    
+    def test_render_file_nonexistent(self):
+        """Test render_file with non-existent file."""
+        result = self.tool.render_file(file_path="/nonexistent/file.txt")
+        assert "error" in result
+        assert "File not found" in result["error"]
+    
+    @patch('praisonai_tools.tools.langextract_tool._get_langextract')
+    @patch('praisonai_tools.tools.langextract_tool._create_annotated_document')
+    def test_render_file_success(self, mock_create_doc, mock_get_lx):
+        """Test successful file rendering."""
+        # Mock langextract
+        mock_lx = Mock()
+        mock_get_lx.return_value = mock_lx
+        
+        # Mock annotated document
+        mock_doc = Mock()
+        mock_create_doc.return_value = mock_doc
+        
+        # Mock visualization methods
+        mock_lx.io.save_annotated_documents = Mock()
+        mock_lx.visualize = Mock()
+        
+        # Create temporary file
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as temp_file:
+            temp_file.write("This is test content with important terms.")
+            temp_file_path = temp_file.name
+        
+        try:
+            result = self.tool.render_file(
+                file_path=temp_file_path,
+                extractions=["important terms"]
+            )
+            
+            assert result["success"] is True
+            assert result["text_length"] > 0
+            
+        finally:
+            os.unlink(temp_file_path)
+
+
+class TestHelperFunctions:
+    """Test helper functions."""
+    
+    def test_get_langextract_not_installed(self):
+        """Test _get_langextract when module not installed."""
+        with patch.dict('sys.modules', {'langextract': None}):
+            with patch('builtins.__import__', side_effect=ImportError):
+                result = _get_langextract()
+                assert result is None
+    
+    @patch('praisonai_tools.tools.langextract_tool._get_langextract')
+    def test_create_annotated_document(self, mock_get_lx):
+        """Test _create_annotated_document function."""
+        # Mock langextract
+        mock_lx = Mock()
+        mock_get_lx.return_value = mock_lx
+        
+        # Mock CharInterval and AnnotatedDocument
+        mock_char_interval = Mock()
+        mock_lx.data.CharInterval.return_value = mock_char_interval
+        mock_annotated_doc = Mock()
+        mock_lx.data.AnnotatedDocument.return_value = mock_annotated_doc
+        
+        text = "John Doe works at OpenAI"
+        extractions = ["John Doe"]
+        document_id = "test"
+        
+        result = _create_annotated_document(text, extractions, document_id)
+        
+        assert result == mock_annotated_doc
+        mock_lx.data.CharInterval.assert_called()
+        mock_lx.data.AnnotatedDocument.assert_called_once()
+    
+    def test_create_annotated_document_no_langextract(self):
+        """Test _create_annotated_document when langextract not available."""
+        with patch('praisonai_tools.tools.langextract_tool._get_langextract', return_value=None):
+            result = _create_annotated_document("text", [], "id")
+            assert result is None
+
+
+class TestToolDecorators:
+    """Test tool decorator functions."""
+    
+    @patch('praisonai_tools.tools.langextract_tool.LangExtractTool')
+    def test_langextract_extract_function(self, mock_tool_class):
+        """Test langextract_extract decorator function."""
+        mock_tool = Mock()
+        mock_tool_class.return_value = mock_tool
+        mock_tool.extract.return_value = {"success": True}
+        
+        result = langextract_extract(
+            text="test text",
+            extractions=["test"],
+            document_id="test-doc"
+        )
+        
+        assert result == {"success": True}
+        mock_tool.extract.assert_called_once_with(
+            text="test text",
+            extractions=["test"],
+            document_id="test-doc",
+            output_path=None,
+            auto_open=False
+        )
+    
+    @patch('praisonai_tools.tools.langextract_tool.LangExtractTool')
+    def test_langextract_render_file_function(self, mock_tool_class):
+        """Test langextract_render_file decorator function."""
+        mock_tool = Mock()
+        mock_tool_class.return_value = mock_tool
+        mock_tool.render_file.return_value = {"success": True}
+        
+        result = langextract_render_file(
+            file_path="/test/path.txt",
+            extractions=["test"]
+        )
+        
+        assert result == {"success": True}
+        mock_tool.render_file.assert_called_once_with(
+            file_path="/test/path.txt",
+            extractions=["test"],
+            output_path=None,
+            auto_open=False
+        )
+
+
+class TestIntegration:
+    """Integration tests with real agentic scenarios."""
+    
+    @patch('praisonai_tools.tools.langextract_tool._get_langextract')
+    @patch('praisonai_tools.tools.langextract_tool._create_annotated_document')
+    def test_contract_analysis_scenario(self, mock_create_doc, mock_get_lx):
+        """Test contract analysis use case."""
+        # Mock langextract
+        mock_lx = Mock()
+        mock_get_lx.return_value = mock_lx
+        mock_create_doc.return_value = Mock()
+        mock_lx.io.save_annotated_documents = Mock()
+        mock_lx.visualize = Mock()
+        
+        # Simulate contract text with key terms
+        contract_text = """
+        This Agreement is entered into between John Doe (the "Client") 
+        and OpenAI Corporation (the "Service Provider") effective 
+        January 1, 2024. The payment terms are Net 30 days.
+        """
+        
+        key_terms = ["John Doe", "OpenAI Corporation", "January 1, 2024", "Net 30 days"]
+        
+        result = langextract_extract(
+            text=contract_text,
+            extractions=key_terms,
+            document_id="contract-001",
+            auto_open=False
+        )
+        
+        assert result["success"] is True
+        assert result["document_id"] == "contract-001"
+        assert result["extractions_count"] == len(key_terms)
+    
+    def test_agent_usage_pattern(self):
+        """Test typical agent usage pattern."""
+        # This would be how an agent uses the tool
+        from praisonai_tools import langextract_extract
+        
+        # Agent analyzes text and wants to highlight findings
+        analysis_text = "The quarterly report shows revenue of $1.2M and profit of $300K."
+        findings = ["$1.2M", "$300K", "quarterly report"]
+        
+        # Without langextract installed, should get helpful error
+        result = langextract_extract(
+            text=analysis_text,
+            extractions=findings,
+            document_id="financial-analysis"
+        )
+        
+        # Should get error about missing langextract
+        assert "error" in result
+        assert "langextract not installed" in result["error"]

--- a/tests/test_langextract_tool.py
+++ b/tests/test_langextract_tool.py
@@ -60,7 +60,7 @@ class TestLangExtractTool:
         
         # Mock visualization methods
         mock_lx.io.save_annotated_documents = Mock()
-        mock_lx.visualize = Mock()
+        mock_lx.visualize = Mock(return_value="<html>mock visualization</html>")
         
         text = "John Doe works at OpenAI"
         extractions = ["John Doe", "OpenAI"]
@@ -96,7 +96,7 @@ class TestLangExtractTool:
         with patch('praisonai_tools.tools.langextract_tool._create_annotated_document') as mock_create_doc:
             mock_create_doc.return_value = Mock()
             mock_lx.io.save_annotated_documents = Mock()
-            mock_lx.visualize = Mock()
+            mock_lx.visualize = Mock(return_value="<html>mock visualization</html>")
             
             with patch('webbrowser.open') as mock_open:
                 with tempfile.TemporaryDirectory() as temp_dir:
@@ -138,7 +138,7 @@ class TestLangExtractTool:
         
         # Mock visualization methods
         mock_lx.io.save_annotated_documents = Mock()
-        mock_lx.visualize = Mock()
+        mock_lx.visualize = Mock(return_value="<html>mock visualization</html>")
         
         # Create temporary file
         with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.txt') as temp_file:
@@ -256,7 +256,7 @@ class TestIntegration:
         mock_get_lx.return_value = mock_lx
         mock_create_doc.return_value = Mock()
         mock_lx.io.save_annotated_documents = Mock()
-        mock_lx.visualize = Mock()
+        mock_lx.visualize = Mock(return_value="<html>mock visualization</html>")
         
         # Simulate contract text with key terms
         contract_text = """
@@ -287,13 +287,13 @@ class TestIntegration:
         analysis_text = "The quarterly report shows revenue of $1.2M and profit of $300K."
         findings = ["$1.2M", "$300K", "quarterly report"]
         
-        # Without langextract installed, should get helpful error
         result = langextract_extract(
             text=analysis_text,
             extractions=findings,
-            document_id="financial-analysis"
+            document_id="financial-analysis",
+            auto_open=False,
         )
-        
-        # Should get error about missing langextract
-        assert "error" in result
-        assert "langextract not installed" in result["error"]
+
+        assert result["success"] is True
+        assert result["document_id"] == "financial-analysis"
+        assert result["extractions_count"] == len(findings)

--- a/tmpc8_hvm6m.html
+++ b/tmpc8_hvm6m.html
@@ -1,0 +1,1 @@
+<html>mock visualization</html>


### PR DESCRIPTION
Fixes #24

## Summary
Implements langextract tools for PraisonAI agents to create interactive HTML visualizations from text with highlighted extractions.

## Changes
- ✅ Implement `langextract_extract` tool for text analysis
- ✅ Implement `langextract_render_file` tool for file analysis
- ✅ Lazy imports with graceful degradation
- ✅ Security warnings for file operations
- ✅ Comprehensive test suite with mocking
- ✅ Usage example with agent integration
- ✅ Optional dependency configuration

## Usage
```python
from praisonai_tools import langextract_extract, langextract_render_file

# Extract from text
result = langextract_extract(
    text="John Doe works at OpenAI",
    extractions=["John Doe", "OpenAI"],
    document_id="contract-analysis"
)
```

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a text extraction and annotation tool that generates interactive HTML visualizations from raw text or uploaded files, with agent integration support and optional auto-open of results.

* **Documentation**
  * Added a runnable example demonstrating text and file analysis, agent integration, and graceful error handling.

* **Tests**
  * Added tests covering success cases, error handling, and integration scenarios.

* **Chores**
  * Added an optional dependency group for the extraction feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->