### PR TITLE
fix(motion-graphics): correct FileTools import path + constructor (v0.2.25)

### DIFF
--- a/praisonai_tools/video/motion_graphics/agent.py
+++ b/praisonai_tools/video/motion_graphics/agent.py
@@ -6,7 +6,7 @@ from typing import Union, Any
 
 try:
     from praisonaiagents import Agent
-    from praisonaiagents.tools import FileTools
+    from praisonaiagents.tools.file_tools import FileTools
 except ImportError:
     # Fallback for development
     Agent = None
@@ -193,8 +193,10 @@ CRITICAL OUTPUT VALIDATION:
 Workspace directory: {workspace}
 """
     
-    # Create tools
-    file_tools = FileTools(base_dir=str(workspace))
+    # Create tools.
+    # FileTools is a utility class with bound methods; pass the instance so the
+    # Agent can register read_file/write_file/list_files as callable tools.
+    file_tools = FileTools()
     render_tools = RenderTools(render_backend, workspace, max_retries)
     
     # Create agent

--- a/praisonai_tools/video/motion_graphics/team.py
+++ b/praisonai_tools/video/motion_graphics/team.py
@@ -6,9 +6,11 @@ from typing import Union, Any, Optional
 
 try:
     from praisonaiagents import Agent, AgentTeam
-    from praisonaiagents.tools import FileTools, search_web
-except ImportError:
-    # Fallback for development
+    from praisonaiagents.tools.file_tools import FileTools
+    # search_web is lazily resolved via praisonaiagents.tools.__getattr__
+    from praisonaiagents.tools import search_web
+except (ImportError, AttributeError):
+    # Fallback for development / partial installs
     Agent = None
     AgentTeam = None
     FileTools = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "praisonai-tools"
-version = "0.2.24"
+version = "0.2.25"
 description = "Extended tools for PraisonAI Agents"
 authors = [
     {name = "Mervin Praison"}


### PR DESCRIPTION
## Hotfix for live-run failures in `motion_graphics_team()` / `create_motion_graphics_agent()`

### Caught via live run of

```python
from praisonai_tools.video.motion_graphics import motion_graphics_team
team = motion_graphics_team()
team.start("Animate Dijkstra's algorithm on a small weighted graph, 30s.")
```

Which failed with:

```
ImportError: praisonaiagents not available. Install with: pip install praisonaiagents
```

…despite `praisonaiagents` being installed and importable. Unit tests never caught this because they mock out `Agent`/`AgentTeam`/`FileTools`.

### Root causes

1. **Wrong import path for `FileTools`**
   `praisonai_tools/video/motion_graphics/agent.py:9` and `team.py:9` did:
   ```python
   from praisonaiagents.tools import FileTools
   ```
   `FileTools` is not exported by the tools package `__getattr__` (only lowercase keys like `file_tools`, `read_file`, etc. are). The import raises `ImportError`, which the broad `except ImportError:` swallows — setting every symbol (`Agent`, `AgentTeam`, `FileTools`, `search_web`) to `None` and making the factory raise the misleading top-level `ImportError`.

2. **`FileTools(base_dir=...)` crashes**
   `agent.py:197` did `FileTools(base_dir=str(workspace))`. The actual class takes no constructor args — methods are bound directly. Even if import had succeeded, the factory would still have raised `TypeError: FileTools() takes no arguments`.

### Fix

```diff
- from praisonaiagents.tools import FileTools
+ from praisonaiagents.tools.file_tools import FileTools
```

```diff
- file_tools = FileTools(base_dir=str(workspace))
+ file_tools = FileTools()
```

Also catch `AttributeError` alongside `ImportError` in `team.py` so lazy-attribute failures fall back cleanly.

### Verification (live, not mocked)

```bash
$ python -c "
from praisonai_tools.video.motion_graphics import motion_graphics_team
team = motion_graphics_team(research=False, code_exploration=False)
print(f'team OK: {len(team.agents)} agents = {[a.name for a in team.agents]}')"
team OK: 2 agents = ['coordinator', 'animator']
```

Deterministic `HtmlRenderBackend` path (Example 01) still renders 1920×1080 MP4 end-to-end in ~5s. All 87/87 unit tests still green.

### Version

Bump `0.2.24` → `0.2.25` (patch).

### Follow-up (not in this PR)

Add one non-mocked smoke test that actually instantiates `motion_graphics_team()` and `create_motion_graphics_agent()` against the real `praisonaiagents` SDK, so future regressions of this class are caught by CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.25.

* **Bug Fixes**
  * Improved error handling for motion graphics tools to gracefully manage missing or unavailable dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->