### PR TITLE
fix(motion-graphics): agent tool wiring + ffmpeg frame clipping (v0.2.26)

### DIFF
--- a/praisonai_tools/video/motion_graphics/agent.py
+++ b/praisonai_tools/video/motion_graphics/agent.py
@@ -1,5 +1,6 @@
 """Motion graphics agent factory."""
 
+import asyncio
 import tempfile
 from pathlib import Path
 from typing import Union, Any
@@ -193,16 +194,47 @@ CRITICAL OUTPUT VALIDATION:
 Workspace directory: {workspace}
 """
     
-    # Create tools.
-    # FileTools is a utility class with bound methods; pass the instance so the
-    # Agent can register read_file/write_file/list_files as callable tools.
+    # Create tools. Expose bound methods individually so the Agent (which
+    # treats each tool entry as a callable) can register them across all LLM
+    # adapters (OpenAI, Anthropic, LiteLLM). Passing class instances is not
+    # portable — the OpenAI adapter logs "Tool ... not recognized".
     file_tools = FileTools()
     render_tools = RenderTools(render_backend, workspace, max_retries)
-    
+
+    # Sync wrappers around the async render tools — the Agent's sync call path
+    # does not await coroutines automatically and would otherwise fail with
+    # "Object of type coroutine is not JSON serializable".
+    def lint_composition(strict: bool = False) -> dict:
+        """Lint the motion graphics composition for common issues."""
+        return asyncio.run(render_tools.lint_composition(strict=strict))
+
+    def render_composition(
+        output_name: str = "video.mp4",
+        fps: int = 30,
+        quality: str = "standard",
+    ) -> dict:
+        """Render the motion graphics composition to MP4."""
+        result = asyncio.run(
+            render_tools.render_composition(
+                output_name=output_name, fps=fps, quality=quality
+            )
+        )
+        # Strip the raw bytes — they are not JSON-serializable for the next
+        # LLM turn and the file is already on disk at result["output_path"].
+        return {k: v for k, v in result.items() if k != "bytes"}
+
+    tool_callables = [
+        file_tools.read_file,
+        file_tools.write_file,
+        file_tools.list_files,
+        lint_composition,
+        render_composition,
+    ]
+
     # Create agent
     agent = Agent(
         instructions=base_instructions + "\n\n" + MOTION_GRAPHICS_SKILL,
-        tools=[file_tools, render_tools],
+        tools=tool_callables,
         llm=llm,
         **agent_kwargs
     )

--- a/praisonai_tools/video/motion_graphics/backend_html.py
+++ b/praisonai_tools/video/motion_graphics/backend_html.py
@@ -231,9 +231,15 @@ class HtmlRenderBackend:
                         # Wait a bit for animations to settle
                         await page.wait_for_timeout(50)
                         
-                        # Capture frame
+                        # Capture frame. Clip to the fixed 1920x1080 viewport —
+                        # `full_page=True` can produce odd-height images when
+                        # content overflows, which libx264 rejects (height must
+                        # be divisible by 2).
                         frame_path = temp_path / f"frame_{frame:06d}.png"
-                        await page.screenshot(path=str(frame_path), full_page=True)
+                        await page.screenshot(
+                            path=str(frame_path),
+                            clip={"x": 0, "y": 0, "width": 1920, "height": 1080},
+                        )
                         frame_paths.append(frame_path)
                     
                     # Encode to MP4 using FFmpeg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "praisonai-tools"
-version = "0.2.25"
+version = "0.2.26"
 description = "Extended tools for PraisonAI Agents"
 authors = [
     {name = "Mervin Praison"}

--- a/tests/unit/video/test_motion_graphics_agent.py
+++ b/tests/unit/video/test_motion_graphics_agent.py
@@ -24,10 +24,23 @@ class MockAgent:
 
 
 class MockFileTools:
-    """Mock FileTools for testing."""
-    
+    """Mock FileTools for testing.
+
+    Exposes the same method surface as `praisonaiagents.tools.file_tools.FileTools`
+    so the factory can reference bound methods as tools.
+    """
+
     def __init__(self, base_dir=""):
         self.base_dir = base_dir
+
+    def read_file(self, filepath, encoding="utf-8"):
+        return ""
+
+    def write_file(self, filepath, content, encoding="utf-8"):
+        return True
+
+    def list_files(self, directory=".", pattern="*"):
+        return []
 
 
 class MockBackend:
@@ -115,7 +128,13 @@ class TestCreateMotionGraphicsAgent:
             
             assert isinstance(agent, MockAgent)
             assert agent.llm == "claude-sonnet-4"
-            assert len(agent.tools) == 2  # FileTools and RenderTools
+            # Tools are now exposed as individual callables (bound methods +
+            # sync render wrappers): read_file, write_file, list_files,
+            # lint_composition, render_composition.
+            assert len(agent.tools) == 5
+            tool_names = {getattr(t, "__name__", "") for t in agent.tools}
+            assert {"read_file", "write_file", "list_files",
+                    "lint_composition", "render_composition"} <= tool_names
             assert "motion graphics specialist" in agent.instructions.lower()
     
     @patch('praisonai_tools.video.motion_graphics.agent.Agent', MockAgent)
@@ -207,14 +226,10 @@ class TestCreateMotionGraphicsAgent:
         with tempfile.TemporaryDirectory() as tmpdir:
             agent = create_motion_graphics_agent(workspace=tmpdir)
             
-            assert len(agent.tools) == 2
-            
-            # Check FileTools
-            file_tools = agent.tools[0]
-            assert isinstance(file_tools, MockFileTools)
-            assert file_tools.base_dir == str(tmpdir)
-            
-            # Check RenderTools
-            render_tools = agent.tools[1]
-            assert isinstance(render_tools, RenderTools)
-            assert render_tools.workspace == Path(tmpdir)
+            # Tools are now exposed as individual callables (bound methods +
+            # sync render wrappers): read_file, write_file, list_files,
+            # lint_composition, render_composition.
+            assert len(agent.tools) == 5
+            tool_names = {getattr(t, "__name__", "") for t in agent.tools}
+            assert {"read_file", "write_file", "list_files",
+                    "lint_composition", "render_composition"} <= tool_names


### PR DESCRIPTION
## Hotfix — agent loop works end-to-end with real LLMs (v0.2.26)

Live-tested Example 03 (`create_motion_graphics_agent`) against gpt-4o-mini. It now produces a real MP4 from an LLM-authored HTML/GSAP composition.

### 3 real bugs found by live testing (all invisible to mocked unit tests)

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | `agent.py` | Passing `FileTools()` / `RenderTools()` class instances as tools → OpenAI adapter logs `Tool ... not recognized` and skips tool calls | Expose bound methods individually: `read_file, write_file, list_files, lint_composition, render_composition` |
| 2 | `agent.py` | `lint_composition` / `render_composition` are async → sync path fails with `Object of type coroutine is not JSON serializable` | Wrap each in a sync function that uses `asyncio.run(...)`; also strip unserialisable `bytes` from render return |
| 3 | `backend_html.py` | `page.screenshot(full_page=True)` captured 1920×1167 when SVG overflowed → libx264: `height not divisible by 2 (1920x1167)` | Clip explicitly: `clip={x:0,y:0,width:1920,height:1080}` |

### Live verification

```bash
PRAISONAI_AUTO_APPROVE=true MOTION_LLM=gpt-4o-mini \
  python examples/python/video/03_motion_graphics_agent_factory.py
```

Produces:

```
index.html   1031 bytes  (LLM-authored by gpt-4o-mini)
intro.mp4    13545 bytes
```

ffprobe on `intro.mp4`:

```
Duration: 00:00:01.50, start: 0.000000, bitrate: 72 kb/s
Stream #0:0: Video: h264 (High) yuv420p, 1920x1080, 64 kb/s, 30 fps
```

### Tests

**87 / 87 unit tests pass** (was 87/87). Updates to `test_motion_graphics_agent.py`:

- `MockFileTools` now exposes `read_file` / `write_file` / `list_files` methods so the factory can reference them as bound methods
- Tool-count assertions updated from `2` (class instances) to `5` (callables)

### Follow-ups that are **not** in this PR (keeps scope tight)

- Example 04 (`motion_graphics_team`) still hits a separate SDK-level bug in hierarchical process (`'Agent' object has no attribute 'execution'`) — needs a one-line fix in `praisonaiagents/agent/chat_mixin.py` (`self.execution` → `getattr(self, 'execution', None)`). Filed separately.
- Add one non-mocked smoke test that actually runs `create_motion_graphics_agent` against a cheap real model with `PRAISONAI_AUTO_APPROVE=true`.

### Version

`0.2.25` → `0.2.26`
