### PR TITLE
feat(linear-tool): add update_issue/add_comment/list_cycles/list_issue_states + OAuth Bearer

### DIFF
--- a/praisonai_tools/tools/linear_tool.py
+++ b/praisonai_tools/tools/linear_tool.py
@@ -9,7 +9,8 @@ Usage:
     issues = linear.list_issues()
 
 Environment Variables:
-    LINEAR_API_KEY: Linear API key
+    LINEAR_API_KEY: Linear personal API key (sent as raw Authorization header)
+    LINEAR_OAUTH_TOKEN: Linear OAuth access token (sent with 'Bearer ' prefix)
 """
 
 import os
@@ -27,24 +28,42 @@ class LinearTool(BaseTool):
     name = "linear"
     description = "Create and manage Linear issues and projects."
     
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        oauth_token: Optional[str] = None,
+    ):
+        # Personal API key takes precedence over OAuth when both are provided
         self.api_key = api_key or os.getenv("LINEAR_API_KEY")
+        self.oauth_token = oauth_token or os.getenv("LINEAR_OAUTH_TOKEN")
         self.api_url = "https://api.linear.app/graphql"
         super().__init__()
-    
+
+    def _auth_header(self) -> Optional[str]:
+        """Return Authorization header value, or None if no credentials configured.
+
+        Personal API keys are sent raw; OAuth tokens require the 'Bearer ' prefix.
+        """
+        if self.api_key:
+            return self.api_key
+        if self.oauth_token:
+            return f"Bearer {self.oauth_token}"
+        return None
+
     def _graphql(self, query: str, variables: Dict = None) -> Dict:
         try:
             import requests
         except ImportError:
             return {"error": "requests not installed"}
-        
-        if not self.api_key:
-            return {"error": "LINEAR_API_KEY required"}
-        
+
+        auth = self._auth_header()
+        if not auth:
+            return {"error": "LINEAR_API_KEY or LINEAR_OAUTH_TOKEN required"}
+
         try:
             resp = requests.post(
                 self.api_url,
-                headers={"Authorization": self.api_key, "Content-Type": "application/json"},
+                headers={"Authorization": auth, "Content-Type": "application/json"},
                 json={"query": query, "variables": variables or {}},
                 timeout=10,
             )
@@ -67,8 +86,18 @@ class LinearTool(BaseTool):
             return self.get_issue(issue_id=issue_id)
         elif action == "create_issue":
             return self.create_issue(title=title, **kwargs)
+        elif action == "update_issue":
+            if title is not None:
+                kwargs.setdefault("title", title)
+            return self.update_issue(issue_id=issue_id, **kwargs)
+        elif action == "add_comment":
+            return self.add_comment(issue_id=issue_id, **kwargs)
         elif action == "list_teams":
             return self.list_teams()
+        elif action == "list_cycles":
+            return self.list_cycles(**kwargs)
+        elif action == "list_issue_states":
+            return self.list_issue_states(**kwargs)
         else:
             return {"error": f"Unknown action: {action}"}
     
@@ -192,6 +221,123 @@ class LinearTool(BaseTool):
         
         teams = result.get("data", {}).get("teams", {}).get("nodes", [])
         return [{"id": t["id"], "name": t["name"], "key": t["key"]} for t in teams]
+
+
+    def update_issue(
+        self,
+        issue_id: str,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        state_id: Optional[str] = None,
+        priority: Optional[int] = None,
+        assignee_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update an existing issue (any subset of fields)."""
+        if not issue_id:
+            return {"error": "issue_id required"}
+
+        update: Dict[str, Any] = {}
+        if title is not None:
+            update["title"] = title
+        if description is not None:
+            update["description"] = description
+        if state_id is not None:
+            update["stateId"] = state_id
+        if priority is not None:
+            update["priority"] = priority
+        if assignee_id is not None:
+            update["assigneeId"] = assignee_id
+
+        if not update:
+            return {"error": "no fields to update"}
+
+        query = """
+        mutation($id: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $id, input: $input) {
+                success
+                issue { id title }
+            }
+        }
+        """
+        result = self._graphql(query, {"id": issue_id, "input": update})
+        if "error" in result:
+            return result
+
+        data = result.get("data", {}).get("issueUpdate", {})
+        if data.get("success"):
+            issue = data.get("issue") or {}
+            return {"success": True, "id": issue.get("id"), "title": issue.get("title")}
+        return {"error": "Failed to update issue"}
+
+    def add_comment(self, issue_id: str, body: str) -> Dict[str, Any]:
+        """Add a comment to an issue.
+
+        When called with an OAuth token configured for ``actor=app`` mode the
+        comment is posted as the application user; with a personal API key it
+        is posted as the owning user.
+        """
+        if not issue_id:
+            return {"error": "issue_id required"}
+        if not body:
+            return {"error": "body required"}
+
+        query = """
+        mutation($input: CommentCreateInput!) {
+            commentCreate(input: $input) {
+                success
+                comment { id url }
+            }
+        }
+        """
+        result = self._graphql(query, {"input": {"issueId": issue_id, "body": body}})
+        if "error" in result:
+            return result
+
+        data = result.get("data", {}).get("commentCreate", {})
+        if data.get("success"):
+            comment = data.get("comment") or {}
+            return {"success": True, "id": comment.get("id"), "url": comment.get("url")}
+        return {"error": "Failed to add comment"}
+
+    def list_cycles(self, team_id: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """List cycles (sprints) for a team."""
+        if not team_id:
+            return [{"error": "team_id required"}]
+
+        query = """
+        query($id: String!, $first: Int!) {
+            team(id: $id) {
+                cycles(first: $first) {
+                    nodes { id name number startsAt endsAt }
+                }
+            }
+        }
+        """
+        result = self._graphql(query, {"id": team_id, "first": limit})
+        if "error" in result:
+            return [result]
+
+        team = result.get("data", {}).get("team") or {}
+        return list(team.get("cycles", {}).get("nodes", []))
+
+    def list_issue_states(self, team_id: str) -> List[Dict[str, Any]]:
+        """List workflow states for a team (Backlog/Todo/In Progress/Done/...)."""
+        if not team_id:
+            return [{"error": "team_id required"}]
+
+        query = """
+        query($id: String!) {
+            team(id: $id) {
+                states { nodes { id name type } }
+            }
+        }
+        """
+        result = self._graphql(query, {"id": team_id})
+        if "error" in result:
+            return [result]
+
+        team = result.get("data", {}).get("team") or {}
+        return list(team.get("states", {}).get("nodes", []))
 
 
 def list_linear_issues(limit: int = 20) -> List[Dict[str, Any]]:

--- a/tests/integration/test_motion_graphics_team.py
+++ b/tests/integration/test_motion_graphics_team.py
@@ -79,7 +79,7 @@ class TestMotionGraphicsTeam:
             # Check code explorer
             code_explorer = team.agents[2]
             assert code_explorer.name == "code_explorer"
-            assert "code exploration specialist" in researcher.instructions.lower()
+            assert "code exploration specialist" in code_explorer.instructions.lower()
             
             # Check animator
             animator = team.agents[3]

--- a/tests/unit/tools/test_linear_tool.py
+++ b/tests/unit/tools/test_linear_tool.py
@@ -1,0 +1,370 @@
+"""Unit tests for LinearTool."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from praisonai_tools.tools.linear_tool import LinearTool, list_linear_issues
+
+
+# ── Auth header ─────────────────────────────────────────────────────
+
+
+class TestAuthHeader:
+    def test_personal_api_key_sent_raw(self):
+        tool = LinearTool(api_key="lin_api_xyz")
+        assert tool._auth_header() == "lin_api_xyz"
+
+    def test_oauth_token_gets_bearer_prefix(self):
+        tool = LinearTool(oauth_token="oauth_abc")
+        assert tool._auth_header() == "Bearer oauth_abc"
+
+    def test_api_key_takes_precedence_over_oauth(self):
+        tool = LinearTool(api_key="lin_api_xyz", oauth_token="oauth_abc")
+        assert tool._auth_header() == "lin_api_xyz"
+
+    def test_no_credentials_returns_none(self):
+        with patch.dict(os.environ, {}, clear=True):
+            tool = LinearTool()
+            assert tool._auth_header() is None
+
+    def test_env_var_fallback_personal(self):
+        with patch.dict(os.environ, {"LINEAR_API_KEY": "envkey"}, clear=True):
+            tool = LinearTool()
+            assert tool._auth_header() == "envkey"
+
+    def test_env_var_fallback_oauth(self):
+        with patch.dict(os.environ, {"LINEAR_OAUTH_TOKEN": "envoauth"}, clear=True):
+            tool = LinearTool()
+            assert tool._auth_header() == "Bearer envoauth"
+
+
+# ── _graphql wiring ─────────────────────────────────────────────────
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+class TestGraphQL:
+    def test_missing_credentials_returns_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            tool = LinearTool()
+            result = tool._graphql("query { viewer { id } }")
+            assert result == {
+                "error": "LINEAR_API_KEY or LINEAR_OAUTH_TOKEN required"
+            }
+
+    def test_sends_personal_api_key_header(self):
+        tool = LinearTool(api_key="lin_api_xyz")
+        with patch("requests.post") as post:
+            post.return_value = _mock_response({"data": {"ok": True}})
+            tool._graphql("query { x }", {"v": 1})
+            kwargs = post.call_args.kwargs
+            assert kwargs["headers"]["Authorization"] == "lin_api_xyz"
+            assert kwargs["json"] == {"query": "query { x }", "variables": {"v": 1}}
+
+    def test_sends_bearer_for_oauth(self):
+        tool = LinearTool(oauth_token="oauth_abc")
+        with patch("requests.post") as post:
+            post.return_value = _mock_response({"data": {"ok": True}})
+            tool._graphql("query { x }")
+            assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer oauth_abc"
+
+    def test_handles_request_exception(self):
+        tool = LinearTool(api_key="x")
+        with patch("requests.post", side_effect=RuntimeError("boom")):
+            assert tool._graphql("q") == {"error": "boom"}
+
+
+# ── list_issues ─────────────────────────────────────────────────────
+
+
+class TestListIssues:
+    def test_returns_normalised_issues(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {
+                "issues": {
+                    "nodes": [
+                        {
+                            "id": "i1",
+                            "title": "Bug",
+                            "state": {"name": "Todo"},
+                            "priority": 2,
+                            "assignee": {"name": "Alice"},
+                        },
+                        {
+                            "id": "i2",
+                            "title": "Feat",
+                            "state": {"name": "Done"},
+                            "priority": 0,
+                            "assignee": None,
+                        },
+                    ]
+                }
+            }
+        }
+        with patch("requests.post", return_value=_mock_response(payload)):
+            issues = tool.list_issues(limit=2)
+
+        assert len(issues) == 2
+        assert issues[0]["assignee"] == "Alice"
+        assert issues[1]["assignee"] is None
+        assert issues[1]["state"] == "Done"
+
+    def test_propagates_error(self):
+        tool = LinearTool(api_key="x")
+        with patch("requests.post", side_effect=RuntimeError("net")):
+            issues = tool.list_issues()
+        assert issues == [{"error": "net"}]
+
+
+# ── get_issue ───────────────────────────────────────────────────────
+
+
+class TestGetIssue:
+    def test_requires_issue_id(self):
+        tool = LinearTool(api_key="x")
+        assert tool.get_issue(issue_id="") == {"error": "issue_id required"}
+
+    def test_returns_normalised_issue(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {
+                "issue": {
+                    "id": "i1",
+                    "title": "T",
+                    "description": "D",
+                    "state": {"name": "Todo"},
+                    "priority": 1,
+                    "assignee": {"name": "A"},
+                }
+            }
+        }
+        with patch("requests.post", return_value=_mock_response(payload)):
+            issue = tool.get_issue(issue_id="i1")
+        assert issue["title"] == "T"
+        assert issue["state"] == "Todo"
+        assert issue["assignee"] == "A"
+
+
+# ── create_issue ────────────────────────────────────────────────────
+
+
+class TestCreateIssue:
+    def test_requires_title(self):
+        tool = LinearTool(api_key="x")
+        assert tool.create_issue(title="", team_id="t") == {"error": "title required"}
+
+    def test_requires_team_id(self):
+        tool = LinearTool(api_key="x")
+        assert tool.create_issue(title="T") == {"error": "team_id required"}
+
+    def test_success(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {"issueCreate": {"success": True, "issue": {"id": "i1", "title": "T"}}}
+        }
+        with patch("requests.post", return_value=_mock_response(payload)) as post:
+            result = tool.create_issue(title="T", team_id="team1", description="D")
+
+        sent = post.call_args.kwargs["json"]["variables"]["input"]
+        assert sent == {"title": "T", "teamId": "team1", "description": "D"}
+        assert result == {"success": True, "id": "i1"}
+
+    def test_failure(self):
+        tool = LinearTool(api_key="x")
+        with patch(
+            "requests.post",
+            return_value=_mock_response({"data": {"issueCreate": {"success": False}}}),
+        ):
+            assert tool.create_issue(title="T", team_id="t") == {
+                "error": "Failed to create issue"
+            }
+
+
+# ── update_issue ────────────────────────────────────────────────────
+
+
+class TestUpdateIssue:
+    def test_requires_issue_id(self):
+        tool = LinearTool(api_key="x")
+        assert tool.update_issue(issue_id="") == {"error": "issue_id required"}
+
+    def test_requires_at_least_one_field(self):
+        tool = LinearTool(api_key="x")
+        assert tool.update_issue(issue_id="i1") == {"error": "no fields to update"}
+
+    def test_only_provided_fields_in_input(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {"issueUpdate": {"success": True, "issue": {"id": "i1", "title": "New"}}}
+        }
+        with patch("requests.post", return_value=_mock_response(payload)) as post:
+            result = tool.update_issue(issue_id="i1", title="New", state_id="s1")
+
+        sent = post.call_args.kwargs["json"]["variables"]["input"]
+        assert sent == {"title": "New", "stateId": "s1"}
+        assert result == {"success": True, "id": "i1", "title": "New"}
+
+    def test_failure(self):
+        tool = LinearTool(api_key="x")
+        with patch(
+            "requests.post",
+            return_value=_mock_response({"data": {"issueUpdate": {"success": False}}}),
+        ):
+            assert tool.update_issue(issue_id="i1", title="T") == {
+                "error": "Failed to update issue"
+            }
+
+
+# ── add_comment ─────────────────────────────────────────────────────
+
+
+class TestAddComment:
+    def test_requires_issue_id(self):
+        tool = LinearTool(api_key="x")
+        assert tool.add_comment(issue_id="", body="hi") == {"error": "issue_id required"}
+
+    def test_requires_body(self):
+        tool = LinearTool(api_key="x")
+        assert tool.add_comment(issue_id="i1", body="") == {"error": "body required"}
+
+    def test_success(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {
+                "commentCreate": {
+                    "success": True,
+                    "comment": {"id": "c1", "url": "https://linear.app/c/c1"},
+                }
+            }
+        }
+        with patch("requests.post", return_value=_mock_response(payload)) as post:
+            result = tool.add_comment(issue_id="i1", body="hello")
+
+        sent = post.call_args.kwargs["json"]["variables"]["input"]
+        assert sent == {"issueId": "i1", "body": "hello"}
+        assert result == {"success": True, "id": "c1", "url": "https://linear.app/c/c1"}
+
+
+# ── list_teams / list_cycles / list_issue_states ────────────────────
+
+
+class TestListTeams:
+    def test_returns_teams(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {
+                "teams": {
+                    "nodes": [
+                        {"id": "t1", "name": "Eng", "key": "ENG"},
+                        {"id": "t2", "name": "Design", "key": "DES"},
+                    ]
+                }
+            }
+        }
+        with patch("requests.post", return_value=_mock_response(payload)):
+            teams = tool.list_teams()
+        assert len(teams) == 2
+        assert teams[0]["key"] == "ENG"
+
+
+class TestListCycles:
+    def test_requires_team_id(self):
+        tool = LinearTool(api_key="x")
+        assert tool.list_cycles(team_id="") == [{"error": "team_id required"}]
+
+    def test_returns_cycles(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {
+                "team": {
+                    "cycles": {
+                        "nodes": [
+                            {
+                                "id": "c1",
+                                "name": "C1",
+                                "number": 1,
+                                "startsAt": "2026-01-01",
+                                "endsAt": "2026-01-15",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        with patch("requests.post", return_value=_mock_response(payload)):
+            cycles = tool.list_cycles(team_id="t1")
+        assert len(cycles) == 1
+        assert cycles[0]["number"] == 1
+
+
+class TestListIssueStates:
+    def test_requires_team_id(self):
+        tool = LinearTool(api_key="x")
+        assert tool.list_issue_states(team_id="") == [{"error": "team_id required"}]
+
+    def test_returns_states(self):
+        tool = LinearTool(api_key="x")
+        payload = {
+            "data": {
+                "team": {
+                    "states": {
+                        "nodes": [
+                            {"id": "s1", "name": "Todo", "type": "unstarted"},
+                            {"id": "s2", "name": "Done", "type": "completed"},
+                        ]
+                    }
+                }
+            }
+        }
+        with patch("requests.post", return_value=_mock_response(payload)):
+            states = tool.list_issue_states(team_id="t1")
+        assert [s["name"] for s in states] == ["Todo", "Done"]
+
+
+# ── run() dispatcher ────────────────────────────────────────────────
+
+
+class TestRunDispatcher:
+    def test_unknown_action(self):
+        tool = LinearTool(api_key="x")
+        assert tool.run(action="bogus") == {"error": "Unknown action: bogus"}
+
+    def test_routes_update_issue(self):
+        tool = LinearTool(api_key="x")
+        with patch.object(tool, "update_issue", return_value={"ok": True}) as m:
+            out = tool.run(action="update_issue", issue_id="i1", title="T")
+        m.assert_called_once_with(issue_id="i1", title="T")
+        assert out == {"ok": True}
+
+    def test_routes_add_comment(self):
+        tool = LinearTool(api_key="x")
+        with patch.object(tool, "add_comment", return_value={"ok": True}) as m:
+            tool.run(action="add_comment", issue_id="i1", body="hi")
+        m.assert_called_once_with(issue_id="i1", body="hi")
+
+    def test_routes_list_cycles(self):
+        tool = LinearTool(api_key="x")
+        with patch.object(tool, "list_cycles", return_value=[]) as m:
+            tool.run(action="list_cycles", team_id="t1", limit=5)
+        m.assert_called_once_with(team_id="t1", limit=5)
+
+    def test_routes_list_issue_states(self):
+        tool = LinearTool(api_key="x")
+        with patch.object(tool, "list_issue_states", return_value=[]) as m:
+            tool.run(action="list-issue-states", team_id="t1")
+        m.assert_called_once_with(team_id="t1")
+
+
+# ── Module-level helper ─────────────────────────────────────────────
+
+
+class TestListLinearIssuesHelper:
+    def test_delegates_to_tool(self):
+        with patch.object(LinearTool, "list_issues", return_value=["x"]) as m:
+            assert list_linear_issues(limit=5) == ["x"]
+        m.assert_called_once_with(limit=5)


### PR DESCRIPTION
## Summary

Extends the existing `LinearTool` with the API surface needed for full agentic Linear workflows (`AgentSession` mention/assignment → plan → execute → comment back → update state). This is the **canonical home** for Linear tools per `AGENTS.md` (`praisonai-tools` = external integrations); also see related discussion on `MervinPraison/PraisonAI#1613`.

## What's new

| Method | Purpose |
|--------|---------|
| `update_issue` | Move state, edit title/description/priority/assignee (any subset) |
| `add_comment` | Post a comment on an issue (works with OAuth `actor=app` mode) |
| `list_cycles` | List sprint cycles for a team (powers 'work everything in current cycle' agents) |
| `list_issue_states` | List workflow states (Backlog/Todo/In Progress/Done/...) for state-id lookup |

Plus OAuth support:
- New `LINEAR_OAUTH_TOKEN` env var (and `oauth_token=` constructor arg)
- Personal API keys are sent as raw `Authorization` header (existing behavior)
- OAuth tokens are sent with the required `Bearer ` prefix (per Linear API spec)
- Personal key takes precedence when both are configured

## Tests

`tests/unit/tools/test_linear_tool.py` — **36 unit tests, all passing**:

```
============================== 36 passed in 0.19s ==============================
```

Coverage:
- Auth header (6) — raw vs Bearer, env-var fallback, no-creds error
- `_graphql` (4) — credentials check, header dispatch (raw + Bearer), exception handling
- `list_issues` / `get_issue` / `create_issue` — happy + error paths
- `update_issue` (4) — required-field guards, partial-input mapping, success, failure
- `add_comment` (3) — required guards, success
- `list_teams` / `list_cycles` / `list_issue_states` — happy + guard paths
- `run()` dispatcher (5) — unknown action, all new routes incl. `title` forwarding

## Backward compatibility

✅ `__init__` adds an optional `oauth_token=` kwarg; existing `LinearTool(api_key=...)` callers unaffected.
✅ All existing methods (`list_issues`, `get_issue`, `create_issue`, `list_teams`) and the `run()` action set are unchanged.

## Verification

```bash
python -m pytest tests/unit/tools/test_linear_tool.py -v
```

## Related

- `MervinPraison/PraisonAI#1612` — Linear integration design issue
- `MervinPraison/PraisonAI#1613` — `LinearBot` adapter (the wrapper-side webhook bot will delegate GraphQL to this tool to stay DRY)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth token authentication support alongside existing API key authentication
  * Added issue update operation supporting title, description, state, priority, and assignee modifications
  * Added issue comment creation capability
  * Added team cycles and issue states retrieval operations

* **Tests**
  * Added comprehensive unit test suite covering authentication methods, all operations, error handling, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->