### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,18 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -2,7 +2,9 @@ name: LLM Cost Analysis
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
+    paths:
+      - "**.py"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `praisonai_tools/fcp_tool/prompting.py` | 199 | openai | gpt-4o | $0.04 | $40.97 |
| `praisonai_tools/recipe_tools/llm_tool.py` | 211 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `praisonai_tools/recipe_tools/llm_tool.py` | 313 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `praisonai_tools/recipe_tools/llm_tool.py` | 248 | anthropic | claude-sonnet-4-20250514 (default) | $0.06 | $62.94 |
| `praisonai_tools/recipe_tools/llm_tool.py` | 325 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `praisonai_tools/recipe_tools/vision_tool.py` | 205 | openai | gpt-4o (default) | $0.01 | $10.00 |
| `praisonai_tools/recipe_tools/vision_tool.py` | 254 | anthropic | claude-sonnet-4-20250514 (default) | $0.02 | $15.00 |
| `praisonai_tools/recipe_tools/whisper_tool.py` | 211 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `praisonai_tools/tools/image_tool.py` | 190 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `praisonai_tools/tools/tts_tool.py` | 167 | openai | tts-1 | N/A | N/A |
| `praisonai_tools/video/transcribe.py` | 187 | openai | base | N/A | N/A |

**Total estimated monthly cost: $539.25**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated LLM cost analysis for pull requests targeting the `main` branch when Python files are changed.
  * Cost analysis results are now available directly within the pull request review workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->