### PR TITLE
Upgrade Firecrawl tool to firecrawl-py v2 SDK + add search()

### DIFF
--- a/praisonai_tools/tools/__init__.py
+++ b/praisonai_tools/tools/__init__.py
@@ -117,6 +117,7 @@ def __getattr__(name):
         # Firecrawl
         "FirecrawlTool": "firecrawl_tool",
         "firecrawl_scrape": "firecrawl_tool",
+        "firecrawl_search": "firecrawl_tool",
         # Serper
         "SerperTool": "serper_tool",
         "serper_search": "serper_tool",
@@ -659,6 +660,7 @@ __all__ = [
     # Firecrawl Tool
     "FirecrawlTool",
     "firecrawl_scrape",
+    "firecrawl_search",
     # Serper Tool
     "SerperTool",
     "serper_search",

--- a/praisonai_tools/tools/firecrawl_tool.py
+++ b/praisonai_tools/tools/firecrawl_tool.py
@@ -38,10 +38,12 @@ class FirecrawlTool(BaseTool):
             if not self.api_key:
                 raise ValueError("FIRECRAWL_API_KEY is required")
             try:
-                from firecrawl import FirecrawlApp
+                from firecrawl import Firecrawl
             except ImportError:
-                raise ImportError("firecrawl-py not installed. Install with: pip install firecrawl-py")
-            self._client = FirecrawlApp(api_key=self.api_key)
+                raise ImportError(
+                    "firecrawl-py>=4 not installed. Install with: pip install 'firecrawl-py>=4'"
+                )
+            self._client = Firecrawl(api_key=self.api_key)
         return self._client
     
     def run(
@@ -68,16 +70,28 @@ class FirecrawlTool(BaseTool):
             return {"error": "FIRECRAWL_API_KEY not configured"}
         
         try:
-            params = {}
+            # firecrawl-py v2 (>=4): kwargs instead of a params dict; returns a
+            # typed Document, not a dict.
+            kwargs: Dict[str, Any] = {}
             if formats:
-                params["formats"] = formats
-            
-            result = self.client.scrape_url(url, params=params if params else None)
-            
+                kwargs["formats"] = formats
+
+            result = self.client.scrape(url, **kwargs)
+
+            # v2 returns a Document object; metadata is a typed DocumentMetadata.
+            # Coerce to a plain dict to keep this tool's return shape stable.
+            metadata = getattr(result, "metadata", None)
+            if metadata is not None and hasattr(metadata, "model_dump"):
+                metadata = metadata.model_dump(exclude_none=True)
+            elif metadata is None:
+                metadata = {}
+
+            markdown = getattr(result, "markdown", None) or ""
+
             return {
                 "url": url,
-                "markdown": result.get("markdown", "")[:5000],
-                "metadata": result.get("metadata", {}),
+                "markdown": markdown[:5000],
+                "metadata": metadata,
             }
         except Exception as e:
             logger.error(f"Firecrawl scrape error: {e}")
@@ -92,18 +106,23 @@ class FirecrawlTool(BaseTool):
             return [{"error": "FIRECRAWL_API_KEY not configured"}]
         
         try:
-            result = self.client.crawl_url(
+            # firecrawl-py v2 (>=4): kwargs instead of a params dict; returns a
+            # typed CrawlJob whose `.data` is a list of Document objects.
+            result = self.client.crawl(
                 url,
-                params={"limit": limit},
+                limit=limit,
                 poll_interval=5,
             )
-            
+
+            data = getattr(result, "data", None) or []
+
             pages = []
-            for page in result.get("data", [])[:limit]:
+            for page in data[:limit]:
+                metadata = getattr(page, "metadata", None)
                 pages.append({
-                    "url": page.get("metadata", {}).get("sourceURL"),
-                    "title": page.get("metadata", {}).get("title"),
-                    "markdown": page.get("markdown", "")[:2000],
+                    "url": getattr(metadata, "source_url", None),
+                    "title": getattr(metadata, "title", None),
+                    "markdown": (getattr(page, "markdown", None) or "")[:2000],
                 })
             return pages
         except Exception as e:

--- a/praisonai_tools/tools/firecrawl_tool.py
+++ b/praisonai_tools/tools/firecrawl_tool.py
@@ -108,6 +108,14 @@ class FirecrawlTool(BaseTool):
             return [{"error": "FIRECRAWL_API_KEY not configured"}]
         
         try:
+            # `limit` may arrive as a string (e.g. "10") or None when invoked by
+            # an LLM/agent; coerce to int so the SDK call and `data[:limit]` slice
+            # below don't raise TypeError.
+            try:
+                limit = int(limit) if limit is not None else 10
+            except (ValueError, TypeError):
+                limit = 10
+
             # firecrawl-py v2 (>=4): kwargs instead of a params dict; returns a
             # typed CrawlJob whose `.data` is a list of Document objects.
             result = self.client.crawl(
@@ -140,6 +148,13 @@ class FirecrawlTool(BaseTool):
             return [{"error": "FIRECRAWL_API_KEY not configured"}]
         
         try:
+            # `limit` may arrive as a string or None from an LLM/agent; coerce to
+            # int so the SDK call and `web[:limit]` slice below don't raise.
+            try:
+                limit = int(limit) if limit is not None else 5
+            except (ValueError, TypeError):
+                limit = 5
+
             # firecrawl-py v2 returns a typed SearchData object whose results are
             # grouped by source; read the web results and coerce to plain dicts.
             result = self.client.search(query, limit=limit)

--- a/praisonai_tools/tools/firecrawl_tool.py
+++ b/praisonai_tools/tools/firecrawl_tool.py
@@ -25,7 +25,7 @@ class FirecrawlTool(BaseTool):
     """Tool for web scraping using Firecrawl."""
     
     name = "firecrawl"
-    description = "Scrape and crawl websites using Firecrawl."
+    description = "Scrape, crawl, and search the web using Firecrawl."
     
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.getenv("FIRECRAWL_API_KEY")
@@ -58,6 +58,8 @@ class FirecrawlTool(BaseTool):
             return self.scrape(url=url, **kwargs)
         elif action == "crawl":
             return self.crawl(url=url, **kwargs)
+        elif action == "search":
+            return self.search(query=kwargs.get("query") or url, limit=kwargs.get("limit", 5))
         else:
             return {"error": f"Unknown action: {action}"}
     
@@ -128,8 +130,40 @@ class FirecrawlTool(BaseTool):
         except Exception as e:
             logger.error(f"Firecrawl crawl error: {e}")
             return [{"error": str(e)}]
+    
+    def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
+        """Search the web and return results."""
+        if not query:
+            return [{"error": "query is required"}]
+        
+        if not self.api_key:
+            return [{"error": "FIRECRAWL_API_KEY not configured"}]
+        
+        try:
+            # firecrawl-py v2 returns a typed SearchData object whose results are
+            # grouped by source; read the web results and coerce to plain dicts.
+            result = self.client.search(query, limit=limit)
+            
+            web = getattr(result, "web", None) or []
+            results = []
+            for item in web[:limit]:
+                results.append({
+                    "url": getattr(item, "url", None),
+                    "title": getattr(item, "title", None),
+                    "description": getattr(item, "description", None),
+                    "markdown": (getattr(item, "markdown", None) or "")[:2000],
+                })
+            return results
+        except Exception as e:
+            logger.error(f"Firecrawl search error: {e}")
+            return [{"error": str(e)}]
 
 
 def firecrawl_scrape(url: str) -> Dict[str, Any]:
     """Scrape URL with Firecrawl."""
     return FirecrawlTool().scrape(url=url)
+
+
+def firecrawl_search(query: str, limit: int = 5) -> List[Dict[str, Any]]:
+    """Search the web with Firecrawl."""
+    return FirecrawlTool().search(query=query, limit=limit)


### PR DESCRIPTION
## What
Two changes to `praisonai_tools/tools/firecrawl_tool.py` (`FirecrawlTool`):
1. **Upgrade from the legacy v1 `firecrawl-py` SDK to v2** (`firecrawl-py>=4`).
2. **Add a `search()` method** (+ a module-level `firecrawl_search` helper), registered in `praisonai_tools/tools/__init__.py`.

## v1 → v2
| Area | v1 | v2 |
|---|---|---|
| Client | `from firecrawl import FirecrawlApp` | `from firecrawl import Firecrawl` |
| scrape | `scrape_url(url, params={...})` → dict | `scrape(url, formats=[...])` → typed `Document` |
| crawl | `crawl_url(url, params={...})` → dict | `crawl(url, limit=...)` → typed `CrawlJob` |

v2 returns typed objects; to keep the tool's public surface stable, the typed responses are read via attribute access and `DocumentMetadata` is coerced back to a plain dict via `model_dump(exclude_none=True)`. `scrape()` still returns a `dict`, `crawl()` still a `list[dict]`. Metadata keys now follow v2 snake_case (e.g. `source_url`). In-code install hint updated to `firecrawl-py>=4`.

## New: search()
Adds `FirecrawlTool.search(query, limit)` (wraps v2 `Firecrawl().search()`) and a module-level `firecrawl_search(query, limit)` helper, registered in `praisonai_tools/tools/__init__.py`. The `run()` dispatcher gains a `search` action.

## Verification
Against `firecrawl-py==4.28.2` (no live API calls):
- `py_compile` passes.
- Introspected the real SDK: `Firecrawl().scrape` accepts `formats=`, `.crawl` accepts `limit=`/`poll_interval=`, `.search` accepts `query=`/`limit=`; the typed returns expose the fields read.
- Smoke-tested scrape / crawl / search + `run()` dispatch with mock typed objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web search capability to the Firecrawl tool, enabling search queries alongside existing scrape and crawl operations.

* **Improvements**
  * Updated Firecrawl tool to support the latest Firecrawl Python client library (version 4.0+), ensuring compatibility with current versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->