### PR TITLE
feat: add JIRA watch tools for issue and project monitoring

### DIFF
--- a/examples/jira_watch_example.py
+++ b/examples/jira_watch_example.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""JIRA Agent watch example using praisonai-tools.
+
+Setup:
+    pip install praisonai-tools jira
+    export JIRA_URL=https://yourcompany.atlassian.net
+    export JIRA_EMAIL=your_email@example.com
+    export JIRA_API_TOKEN=your_api_token
+"""
+
+import os
+
+from praisonaiagents import Agent
+from praisonai_tools import jira_tools
+
+
+def main():
+    if not os.getenv("JIRA_API_TOKEN"):
+        print("Set JIRA_API_TOKEN, JIRA_EMAIL (or JIRA_USERNAME), and JIRA_URL")
+        return
+
+    agent = Agent(
+        name="JIRA Monitor Agent",
+        instructions=(
+            "You monitor JIRA issues and projects. Use jira_watch_issue, "
+            "jira_watch_project, jira_get_issue_info, and jira_search_issues."
+        ),
+        tools=jira_tools(),
+        llm="gpt-4o-mini",
+    )
+
+    print("JIRA watch tools ready. Example prompts:")
+    print("  Get info for PROJ-123")
+    print("  Search open issues: project = PROJ AND status = Open")
+    print("  Watch PROJ-123 for changes since 2024-01-01T00:00:00")
+
+    while True:
+        try:
+            user_input = input("\nYou: ").strip()
+            if user_input.lower() in {"quit", "exit", "q"}:
+                break
+            if not user_input:
+                continue
+            print("Agent:", agent.start(user_input))
+        except KeyboardInterrupt:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/jira_watch_example.py
+++ b/examples/jira_watch_example.py
@@ -15,8 +15,13 @@ from praisonai_tools import jira_tools
 
 
 def main():
-    if not os.getenv("JIRA_API_TOKEN"):
-        print("Set JIRA_API_TOKEN, JIRA_EMAIL (or JIRA_USERNAME), and JIRA_URL")
+    jira_url = os.getenv("JIRA_URL")
+    jira_token = os.getenv("JIRA_API_TOKEN")
+    jira_email = os.getenv("JIRA_EMAIL")
+    jira_username = os.getenv("JIRA_USERNAME")
+
+    if not jira_url or not jira_token or not (jira_email or jira_username):
+        print("Set JIRA_URL, JIRA_API_TOKEN, and JIRA_EMAIL (or JIRA_USERNAME)")
         return
 
     agent = Agent(

--- a/praisonai_tools/tools/__init__.py
+++ b/praisonai_tools/tools/__init__.py
@@ -139,6 +139,11 @@ def __getattr__(name):
         "jira_get_transitions": "jira_tool",
         "jira_move_issue": "jira_tool",
         "jira_create_task": "jira_tool",
+        "jira_watch_issue": "jira_watch_tool",
+        "jira_watch_project": "jira_watch_tool",
+        "jira_get_issue_info": "jira_watch_tool",
+        "jira_search_issues": "jira_watch_tool",
+        "jira_tools": "jira_watch_tool",
         # Trello
         "TrelloTool": "trello_tool",
         "list_trello_boards": "trello_tool",
@@ -681,6 +686,11 @@ __all__ = [
     "jira_get_transitions",
     "jira_move_issue",
     "jira_create_task",
+    "jira_watch_issue",
+    "jira_watch_project",
+    "jira_get_issue_info",
+    "jira_search_issues",
+    "jira_tools",
     # Trello Tool
     "TrelloTool",
     "list_trello_boards",

--- a/praisonai_tools/tools/jira_watch_tool.py
+++ b/praisonai_tools/tools/jira_watch_tool.py
@@ -133,7 +133,7 @@ def jira_watch_issue(
 
             recent_changes = []
             if issue.changelog and issue.changelog.histories:
-                for history in issue.changelog.histories[-3:]:
+                for history in issue.changelog.histories:
                     try:
                         history_dt = _parse_datetime(history.created)
                     except (ValueError, TypeError):
@@ -174,8 +174,9 @@ def jira_watch_issue(
                 result += f"Assignee: {change['assignee']}\n"
                 result += f"Priority: {change['priority']}\n"
                 if change.get("recent_changes"):
-                    result += "Recent field changes:\n"
-                    for rc in change["recent_changes"]:
+                    field_changes = change["recent_changes"]
+                    result += f"Recent field changes ({len(field_changes)}):\n"
+                    for rc in field_changes[-10:]:
                         result += f"  - {rc['field']}: '{rc['from']}' → '{rc['to']}' by {rc['author']}\n"
                 if change.get("recent_comments"):
                     result += "Recent comments:\n"

--- a/praisonai_tools/tools/jira_watch_tool.py
+++ b/praisonai_tools/tools/jira_watch_tool.py
@@ -4,11 +4,20 @@ import logging
 import os
 import re
 import time
+from datetime import datetime, timezone
 from typing import Optional
 
 from praisonai_tools.tools.decorator import tool
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_datetime(ts_str: str) -> datetime:
+    """Parse a timestamp string into a timezone-aware datetime for safe comparison."""
+    dt = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def _get_jira_connection(
@@ -58,6 +67,31 @@ def _validate_project_key(project_key: str) -> bool:
     return True
 
 
+def _validate_issue_key(issue_key: str) -> bool:
+    """Validate JIRA issue key to prevent path traversal or API abuse."""
+    if not re.match(r"^[A-Za-z0-9_-]+$", issue_key):
+        raise ValueError(
+            f"Invalid issue key format: {issue_key}. "
+            "Must contain only alphanumeric characters, underscores, and hyphens."
+        )
+    return True
+
+
+def _validate_timestamp(timestamp: str) -> str:
+    """Validate and normalize a timestamp to prevent JQL injection.
+
+    Returns a canonical 'YYYY-MM-DD HH:MM' string safe for JQL interpolation.
+    """
+    try:
+        dt = _parse_datetime(timestamp)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"Invalid timestamp format: {timestamp}. "
+            "Use ISO-8601, e.g. 2024-01-01T00:00:00Z"
+        ) from exc
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
 @tool
 def jira_watch_issue(
     issue_key: str,
@@ -69,6 +103,8 @@ def jira_watch_issue(
 ) -> str:
     """Check a specific JIRA issue for changes since a timestamp."""
     try:
+        _validate_issue_key(issue_key)
+        since_dt = _parse_datetime(since_timestamp) if since_timestamp else None
         jira = _get_jira_connection(url, username, token, email)
         issue = jira.issue(issue_key, expand="changelog")
         current_updated = issue.fields.updated
@@ -86,7 +122,7 @@ def jira_watch_issue(
             return result
 
         changes_detected = []
-        if current_updated > since_timestamp:
+        if _parse_datetime(current_updated) > since_dt:
             change_info = {
                 "timestamp": current_updated,
                 "status": current_status,
@@ -98,13 +134,17 @@ def jira_watch_issue(
             recent_changes = []
             if issue.changelog and issue.changelog.histories:
                 for history in issue.changelog.histories[-3:]:
-                    if history.created > since_timestamp:
+                    try:
+                        history_dt = _parse_datetime(history.created)
+                    except (ValueError, TypeError):
+                        continue
+                    if history_dt > since_dt:
                         for item in history.items:
                             recent_changes.append({
                                 "field": item.field,
                                 "from": item.fromString,
                                 "to": item.toString,
-                                "author": history.author.displayName,
+                                "author": history.author.displayName if history.author else "System",
                                 "created": history.created,
                             })
 
@@ -113,9 +153,13 @@ def jira_watch_issue(
 
             comment_changes = []
             for comment in jira.comments(issue_key):
-                if comment.created > since_timestamp:
+                try:
+                    comment_dt = _parse_datetime(comment.created)
+                except (ValueError, TypeError):
+                    continue
+                if comment_dt > since_dt:
                     comment_changes.append({
-                        "author": comment.author.displayName,
+                        "author": comment.author.displayName if comment.author else "Unknown",
                         "body": comment.body[:500],
                         "created": comment.created,
                     })
@@ -158,6 +202,7 @@ def jira_watch_project(
     """Check a JIRA project for new issues and updates since a timestamp."""
     try:
         _validate_project_key(project_key)
+        since_for_jql = _validate_timestamp(since_timestamp) if since_timestamp else None
         jira = _get_jira_connection(url, username, token, email)
 
         project_changes = {
@@ -168,27 +213,27 @@ def jira_watch_project(
 
         if not since_timestamp:
             recent_jql = f"project = {project_key} ORDER BY updated DESC"
-            recent_issues = jira.search_issues(recent_jql, maxResults=20)
+            recent_issues = jira.search_issues(recent_jql, maxResults=10)
             result = f"JIRA project {project_key} recent activity ({len(recent_issues)} issues):\n"
-            for issue in recent_issues[:10]:
+            for issue in recent_issues:
                 result += f"  {issue.key}: {issue.fields.summary[:60]}...\n"
                 result += f"    Status: {issue.fields.status.name}, Updated: {issue.fields.updated}\n"
             return result
 
-        new_jql = f'project = {project_key} AND created >= "{since_timestamp}" ORDER BY created DESC'
+        new_jql = f'project = {project_key} AND created >= "{since_for_jql}" ORDER BY created DESC'
         for issue in jira.search_issues(new_jql, maxResults=50):
             project_changes["new_issues"].append({
                 "key": issue.key,
                 "summary": issue.fields.summary,
                 "status": issue.fields.status.name,
                 "assignee": issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned",
-                "creator": issue.fields.creator.displayName,
+                "creator": issue.fields.creator.displayName if issue.fields.creator else "Unknown",
                 "created": issue.fields.created,
             })
 
         updated_jql = (
-            f'project = {project_key} AND updated >= "{since_timestamp}" '
-            f'AND created < "{since_timestamp}" ORDER BY updated DESC'
+            f'project = {project_key} AND updated >= "{since_for_jql}" '
+            f'AND created < "{since_for_jql}" ORDER BY updated DESC'
         )
         for issue in jira.search_issues(updated_jql, maxResults=50):
             project_changes["updated_issues"].append({
@@ -231,6 +276,7 @@ def jira_get_issue_info(
 ) -> str:
     """Get detailed information about a specific JIRA issue."""
     try:
+        _validate_issue_key(issue_key)
         jira = _get_jira_connection(url, username, token, email)
         issue = jira.issue(issue_key, expand="changelog,comments")
 
@@ -240,18 +286,22 @@ def jira_get_issue_info(
         result += f"Priority: {issue.fields.priority.name if issue.fields.priority else 'None'}\n"
         assignee = issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
         result += f"Assignee: {assignee}\n"
-        result += f"Reporter: {issue.fields.reporter.displayName}\n"
+        reporter = issue.fields.reporter.displayName if issue.fields.reporter else "Unknown"
+        result += f"Reporter: {reporter}\n"
         result += f"Created: {issue.fields.created}\n"
         result += f"Updated: {issue.fields.updated}\n"
 
         if issue.fields.description:
-            result += f"Description: {issue.fields.description[:500]}...\n"
+            desc = issue.fields.description
+            suffix = "..." if len(desc) > 500 else ""
+            result += f"Description: {desc[:500]}{suffix}\n"
 
         comments = jira.comments(issue_key)
         if comments:
             result += f"\nRecent Comments ({len(comments[-3:])}):\n"
             for comment in comments[-3:]:
-                result += f"  - {comment.author.displayName} ({comment.created}): {comment.body[:200]}...\n"
+                author = comment.author.displayName if comment.author else "Unknown"
+                result += f"  - {author} ({comment.created}): {comment.body[:200]}...\n"
 
         return result
 

--- a/praisonai_tools/tools/jira_watch_tool.py
+++ b/praisonai_tools/tools/jira_watch_tool.py
@@ -1,0 +1,302 @@
+"""JIRA watch tools for PraisonAI Agents — monitor issues and projects for changes."""
+
+import logging
+import os
+import re
+import time
+from typing import Optional
+
+from praisonai_tools.tools.decorator import tool
+
+logger = logging.getLogger(__name__)
+
+
+def _get_jira_connection(
+    url: Optional[str] = None,
+    username: Optional[str] = None,
+    token: Optional[str] = None,
+    email: Optional[str] = None,
+):
+    """Create a JIRA connection with cloud or server authentication."""
+    try:
+        from jira import JIRA
+    except ImportError as exc:
+        raise ImportError(
+            "JIRA library not installed. Install with: pip install jira"
+        ) from exc
+
+    url = url or os.getenv("JIRA_URL")
+    username = username or os.getenv("JIRA_USERNAME")
+    token = token or os.getenv("JIRA_API_TOKEN")
+    email = email or os.getenv("JIRA_EMAIL")
+
+    if not url:
+        raise ValueError("JIRA URL is required (parameter or JIRA_URL env var)")
+
+    if email and token:
+        auth = (email, token)
+    elif username and token:
+        auth = (username, token)
+    else:
+        raise ValueError(
+            "JIRA authentication required. Provide either:\n"
+            "- email + token (for cloud JIRA)\n"
+            "- username + token (for server JIRA)\n"
+            "Or set JIRA_EMAIL, JIRA_USERNAME, and JIRA_API_TOKEN"
+        )
+
+    return JIRA(server=url, basic_auth=auth)
+
+
+def _validate_project_key(project_key: str) -> bool:
+    """Validate JIRA project key to prevent JQL injection."""
+    if not re.match(r"^[A-Z][A-Z0-9_]*$", project_key):
+        raise ValueError(
+            f"Invalid project key format: {project_key}. "
+            "Must start with a letter and contain only uppercase letters, numbers, and underscores."
+        )
+    return True
+
+
+@tool
+def jira_watch_issue(
+    issue_key: str,
+    url: Optional[str] = None,
+    since_timestamp: Optional[str] = None,
+    username: Optional[str] = None,
+    token: Optional[str] = None,
+    email: Optional[str] = None,
+) -> str:
+    """Check a specific JIRA issue for changes since a timestamp."""
+    try:
+        jira = _get_jira_connection(url, username, token, email)
+        issue = jira.issue(issue_key, expand="changelog")
+        current_updated = issue.fields.updated
+        current_status = issue.fields.status.name
+
+        if not since_timestamp:
+            result = f"JIRA issue {issue_key} current state:\n"
+            result += f"Status: {current_status}\n"
+            result += f"Summary: {issue.fields.summary}\n"
+            assignee = issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
+            result += f"Assignee: {assignee}\n"
+            priority = issue.fields.priority.name if issue.fields.priority else "None"
+            result += f"Priority: {priority}\n"
+            result += f"Updated: {current_updated}\n"
+            return result
+
+        changes_detected = []
+        if current_updated > since_timestamp:
+            change_info = {
+                "timestamp": current_updated,
+                "status": current_status,
+                "summary": issue.fields.summary,
+                "assignee": issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned",
+                "priority": issue.fields.priority.name if issue.fields.priority else "None",
+            }
+
+            recent_changes = []
+            if issue.changelog and issue.changelog.histories:
+                for history in issue.changelog.histories[-3:]:
+                    if history.created > since_timestamp:
+                        for item in history.items:
+                            recent_changes.append({
+                                "field": item.field,
+                                "from": item.fromString,
+                                "to": item.toString,
+                                "author": history.author.displayName,
+                                "created": history.created,
+                            })
+
+            change_info["recent_changes"] = recent_changes
+            changes_detected.append(change_info)
+
+            comment_changes = []
+            for comment in jira.comments(issue_key):
+                if comment.created > since_timestamp:
+                    comment_changes.append({
+                        "author": comment.author.displayName,
+                        "body": comment.body[:500],
+                        "created": comment.created,
+                    })
+            if comment_changes:
+                change_info["recent_comments"] = comment_changes
+
+        if changes_detected:
+            result = f"JIRA issue {issue_key} - changes detected since {since_timestamp}:\n"
+            for i, change in enumerate(changes_detected, 1):
+                result += f"\n--- Change {i} at {change['timestamp']} ---\n"
+                result += f"Status: {change['status']}\n"
+                result += f"Assignee: {change['assignee']}\n"
+                result += f"Priority: {change['priority']}\n"
+                if change.get("recent_changes"):
+                    result += "Recent field changes:\n"
+                    for rc in change["recent_changes"]:
+                        result += f"  - {rc['field']}: '{rc['from']}' → '{rc['to']}' by {rc['author']}\n"
+                if change.get("recent_comments"):
+                    result += "Recent comments:\n"
+                    for comment in change["recent_comments"]:
+                        result += f"  - {comment['author']} ({comment['created']}): {comment['body'][:200]}...\n"
+            return result
+
+        return f"No changes detected in JIRA issue {issue_key} since {since_timestamp}"
+
+    except Exception as e:
+        logger.error("Failed to watch JIRA issue: %s", e)
+        return f"Error watching JIRA issue {issue_key}: {e}"
+
+
+@tool
+def jira_watch_project(
+    project_key: str,
+    url: Optional[str] = None,
+    since_timestamp: Optional[str] = None,
+    username: Optional[str] = None,
+    token: Optional[str] = None,
+    email: Optional[str] = None,
+) -> str:
+    """Check a JIRA project for new issues and updates since a timestamp."""
+    try:
+        _validate_project_key(project_key)
+        jira = _get_jira_connection(url, username, token, email)
+
+        project_changes = {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "new_issues": [],
+            "updated_issues": [],
+        }
+
+        if not since_timestamp:
+            recent_jql = f"project = {project_key} ORDER BY updated DESC"
+            recent_issues = jira.search_issues(recent_jql, maxResults=20)
+            result = f"JIRA project {project_key} recent activity ({len(recent_issues)} issues):\n"
+            for issue in recent_issues[:10]:
+                result += f"  {issue.key}: {issue.fields.summary[:60]}...\n"
+                result += f"    Status: {issue.fields.status.name}, Updated: {issue.fields.updated}\n"
+            return result
+
+        new_jql = f'project = {project_key} AND created >= "{since_timestamp}" ORDER BY created DESC'
+        for issue in jira.search_issues(new_jql, maxResults=50):
+            project_changes["new_issues"].append({
+                "key": issue.key,
+                "summary": issue.fields.summary,
+                "status": issue.fields.status.name,
+                "assignee": issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned",
+                "creator": issue.fields.creator.displayName,
+                "created": issue.fields.created,
+            })
+
+        updated_jql = (
+            f'project = {project_key} AND updated >= "{since_timestamp}" '
+            f'AND created < "{since_timestamp}" ORDER BY updated DESC'
+        )
+        for issue in jira.search_issues(updated_jql, maxResults=50):
+            project_changes["updated_issues"].append({
+                "key": issue.key,
+                "summary": issue.fields.summary,
+                "status": issue.fields.status.name,
+                "assignee": issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned",
+                "updated": issue.fields.updated,
+            })
+
+        if project_changes["new_issues"] or project_changes["updated_issues"]:
+            result = f"JIRA project {project_key} - changes detected since {since_timestamp}:\n"
+            result += f"\n--- Activity at {project_changes['timestamp']} ---\n"
+            if project_changes["new_issues"]:
+                result += f"New issues ({len(project_changes['new_issues'])}):\n"
+                for issue in project_changes["new_issues"]:
+                    result += f"  {issue['key']}: {issue['summary'][:80]}...\n"
+                    result += f"     Status: {issue['status']}, Assignee: {issue['assignee']}, Created: {issue['created']}\n"
+            if project_changes["updated_issues"]:
+                result += f"Updated issues ({len(project_changes['updated_issues'])}):\n"
+                for issue in project_changes["updated_issues"]:
+                    result += f"  {issue['key']}: {issue['summary'][:80]}...\n"
+                    result += f"     Status: {issue['status']}, Updated: {issue['updated']}\n"
+            return result
+
+        return f"No changes detected in JIRA project {project_key} since {since_timestamp}"
+
+    except Exception as e:
+        logger.error("Failed to watch JIRA project: %s", e)
+        return f"Error watching JIRA project {project_key}: {e}"
+
+
+@tool
+def jira_get_issue_info(
+    issue_key: str,
+    url: Optional[str] = None,
+    username: Optional[str] = None,
+    token: Optional[str] = None,
+    email: Optional[str] = None,
+) -> str:
+    """Get detailed information about a specific JIRA issue."""
+    try:
+        jira = _get_jira_connection(url, username, token, email)
+        issue = jira.issue(issue_key, expand="changelog,comments")
+
+        result = f"JIRA Issue: {issue.key}\n"
+        result += f"Summary: {issue.fields.summary}\n"
+        result += f"Status: {issue.fields.status.name}\n"
+        result += f"Priority: {issue.fields.priority.name if issue.fields.priority else 'None'}\n"
+        assignee = issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
+        result += f"Assignee: {assignee}\n"
+        result += f"Reporter: {issue.fields.reporter.displayName}\n"
+        result += f"Created: {issue.fields.created}\n"
+        result += f"Updated: {issue.fields.updated}\n"
+
+        if issue.fields.description:
+            result += f"Description: {issue.fields.description[:500]}...\n"
+
+        comments = jira.comments(issue_key)
+        if comments:
+            result += f"\nRecent Comments ({len(comments[-3:])}):\n"
+            for comment in comments[-3:]:
+                result += f"  - {comment.author.displayName} ({comment.created}): {comment.body[:200]}...\n"
+
+        return result
+
+    except Exception as e:
+        logger.error("Failed to get JIRA issue info: %s", e)
+        return f"Error getting JIRA issue {issue_key}: {e}"
+
+
+@tool
+def jira_search_issues(
+    jql: str,
+    url: Optional[str] = None,
+    max_results: int = 20,
+    username: Optional[str] = None,
+    token: Optional[str] = None,
+    email: Optional[str] = None,
+) -> str:
+    """Search JIRA issues using JQL (JIRA Query Language)."""
+    try:
+        jira = _get_jira_connection(url, username, token, email)
+        issues = jira.search_issues(jql, maxResults=max_results)
+
+        if not issues:
+            return f"No issues found for JQL: {jql}"
+
+        result = f"Found {len(issues)} issues for JQL: {jql}\n\n"
+        for issue in issues:
+            assignee = issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
+            result += f"{issue.key}: {issue.fields.summary}\n"
+            result += f"  Status: {issue.fields.status.name}\n"
+            result += f"  Assignee: {assignee}\n"
+            result += f"  Updated: {issue.fields.updated}\n\n"
+
+        return result
+
+    except Exception as e:
+        logger.error("Failed to search JIRA issues: %s", e)
+        return f"Error searching JIRA issues: {e}"
+
+
+def jira_tools():
+    """Return all JIRA watch tools as a collection for agent registration."""
+    return [
+        jira_watch_issue,
+        jira_watch_project,
+        jira_get_issue_info,
+        jira_search_issues,
+    ]

--- a/tests/unit/tools/test_jira_watch_tool.py
+++ b/tests/unit/tools/test_jira_watch_tool.py
@@ -1,0 +1,175 @@
+"""Unit tests for JIRA watch tools."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from praisonai_tools.tools.jira_watch_tool import (
+    jira_watch_issue,
+    jira_watch_project,
+    jira_get_issue_info,
+    jira_search_issues,
+    jira_tools,
+    _get_jira_connection,
+    _validate_project_key,
+)
+
+
+class TestJIRAConnection:
+    @patch("jira.JIRA")
+    def test_connection_with_email_token(self, mock_jira):
+        _get_jira_connection(
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+        )
+        mock_jira.assert_called_once_with(
+            server="https://test.atlassian.net",
+            basic_auth=("test@example.com", "test_token"),
+        )
+
+    @patch("jira.JIRA")
+    def test_connection_with_username_token(self, mock_jira):
+        _get_jira_connection(
+            url="https://test.atlassian.net",
+            username="test_user",
+            token="test_token",
+        )
+        mock_jira.assert_called_once_with(
+            server="https://test.atlassian.net",
+            basic_auth=("test_user", "test_token"),
+        )
+
+    def test_connection_missing_auth(self):
+        with pytest.raises(ValueError, match="JIRA authentication required"):
+            _get_jira_connection(url="https://test.atlassian.net")
+
+    def test_connection_missing_url(self):
+        with pytest.raises(ValueError, match="JIRA URL is required"):
+            _get_jira_connection(email="test@example.com", token="token")
+
+
+class TestJIRAGetIssueInfo:
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_get_issue_info_success(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+
+        mock_issue = Mock()
+        mock_issue.key = "PROJ-123"
+        mock_issue.fields.summary = "Test issue"
+        mock_issue.fields.status.name = "Open"
+        mock_issue.fields.priority.name = "High"
+        mock_issue.fields.assignee.displayName = "John Doe"
+        mock_issue.fields.reporter.displayName = "Jane Smith"
+        mock_issue.fields.created = "2024-01-01T10:00:00"
+        mock_issue.fields.updated = "2024-01-02T15:30:00"
+        mock_issue.fields.description = "Test description"
+
+        mock_jira.issue.return_value = mock_issue
+        mock_jira.comments.return_value = []
+
+        result = jira_get_issue_info(
+            issue_key="PROJ-123",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+        )
+
+        assert "PROJ-123" in result
+        assert "Test issue" in result
+        assert "Open" in result
+
+
+class TestJIRASearchIssues:
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_search_issues_success(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+
+        mock_issue = Mock()
+        mock_issue.key = "PROJ-123"
+        mock_issue.fields.summary = "First issue"
+        mock_issue.fields.status.name = "Open"
+        mock_issue.fields.assignee.displayName = "John Doe"
+        mock_issue.fields.updated = "2024-01-01T10:00:00"
+
+        mock_jira.search_issues.return_value = [mock_issue]
+
+        result = jira_search_issues(
+            jql="project = PROJ",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+        )
+
+        assert "Found 1 issues" in result
+        assert "PROJ-123" in result
+
+
+class TestJIRAWatchIssue:
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_issue_current_state(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+
+        mock_issue = Mock()
+        mock_issue.fields.updated = "2024-01-01T10:00:00"
+        mock_issue.fields.status.name = "Open"
+        mock_issue.fields.summary = "Test issue"
+        mock_issue.fields.assignee.displayName = "John Doe"
+        mock_issue.fields.priority.name = "High"
+
+        mock_jira.issue.return_value = mock_issue
+
+        result = jira_watch_issue(
+            issue_key="PROJ-123",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+        )
+
+        assert "current state" in result
+        assert "PROJ-123" in result
+
+
+class TestJIRAWatchProject:
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_project_recent_activity(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+
+        mock_issue = Mock()
+        mock_issue.key = "PROJ-123"
+        mock_issue.fields.summary = "Test issue"
+        mock_issue.fields.status.name = "Open"
+        mock_issue.fields.updated = "2024-01-01T10:00:00"
+
+        mock_jira.search_issues.return_value = [mock_issue]
+
+        result = jira_watch_project(
+            project_key="PROJ",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+        )
+
+        assert "recent activity" in result
+        assert "PROJ-123" in result
+
+
+class TestJIRAValidation:
+    def test_validate_project_key_valid(self):
+        assert _validate_project_key("PROJ")
+        assert _validate_project_key("MY_PROJECT")
+
+    def test_validate_project_key_invalid(self):
+        with pytest.raises(ValueError):
+            _validate_project_key("proj")
+        with pytest.raises(ValueError):
+            _validate_project_key("PROJ OR 1=1")
+
+
+def test_jira_tools_collection():
+    tools = jira_tools()
+    assert isinstance(tools, list)
+    assert len(tools) == 4

--- a/tests/unit/tools/test_jira_watch_tool.py
+++ b/tests/unit/tools/test_jira_watch_tool.py
@@ -16,6 +16,8 @@ from praisonai_tools.tools.jira_watch_tool import (  # noqa: E402
     jira_tools,
     _get_jira_connection,
     _validate_project_key,
+    _validate_issue_key,
+    _validate_timestamp,
 )
 
 
@@ -44,7 +46,9 @@ class TestJIRAConnection:
             basic_auth=("test_user", "test_token"),
         )
 
-    def test_connection_missing_auth(self):
+    def test_connection_missing_auth(self, monkeypatch):
+        for var in ("JIRA_EMAIL", "JIRA_USERNAME", "JIRA_API_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
         with pytest.raises(ValueError, match="JIRA authentication required"):
             _get_jira_connection(url="https://test.atlassian.net")
 
@@ -172,6 +176,99 @@ class TestJIRAValidation:
             _validate_project_key("proj")
         with pytest.raises(ValueError):
             _validate_project_key("PROJ OR 1=1")
+
+    def test_validate_issue_key_valid(self):
+        assert _validate_issue_key("PROJ-123")
+        assert _validate_issue_key("abc_123")
+
+    def test_validate_issue_key_invalid(self):
+        with pytest.raises(ValueError):
+            _validate_issue_key("../secret")
+        with pytest.raises(ValueError):
+            _validate_issue_key('PROJ-1" OR "1"="1')
+
+    def test_validate_timestamp_valid(self):
+        assert _validate_timestamp("2024-01-01T00:00:00Z") == "2024-01-01 00:00"
+        assert _validate_timestamp("2024-01-01T10:30:00") == "2024-01-01 10:30"
+
+    def test_validate_timestamp_rejects_injection(self):
+        with pytest.raises(ValueError):
+            _validate_timestamp('2024-01-01" OR project = SECRET AND created >= "2024-01-01')
+
+
+class TestJIRAWatchSinceTimestamp:
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_issue_no_change(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+        mock_issue = Mock()
+        mock_issue.fields.updated = "2024-01-01T10:00:00+00:00"
+        mock_issue.fields.status.name = "Open"
+        mock_issue.fields.summary = "Test issue"
+        mock_issue.changelog.histories = []
+        mock_jira.issue.return_value = mock_issue
+
+        result = jira_watch_issue(
+            issue_key="PROJ-123",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+            since_timestamp="2024-06-01T00:00:00Z",
+        )
+        assert "No changes detected" in result
+
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_issue_change_detected(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+        mock_issue = Mock()
+        mock_issue.fields.updated = "2024-06-15T10:00:00+00:00"
+        mock_issue.fields.status.name = "Done"
+        mock_issue.fields.summary = "Test issue"
+        mock_issue.fields.assignee.displayName = "John Doe"
+        mock_issue.fields.priority.name = "High"
+        mock_issue.changelog.histories = []
+        mock_jira.issue.return_value = mock_issue
+        mock_jira.comments.return_value = []
+
+        result = jira_watch_issue(
+            issue_key="PROJ-123",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+            since_timestamp="2024-01-01T00:00:00Z",
+        )
+        assert "changes detected" in result
+        assert "PROJ-123" in result
+
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_project_since_timestamp_no_injection(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+        mock_jira.search_issues.return_value = []
+
+        result = jira_watch_project(
+            project_key="PROJ",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+            since_timestamp="2024-01-01T00:00:00Z",
+        )
+        assert "No changes detected" in result
+        for call in mock_jira.search_issues.call_args_list:
+            assert '2024-01-01 00:00' in call.args[0]
+
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_project_rejects_bad_timestamp(self, mock_connection):
+        mock_connection.return_value = Mock()
+        result = jira_watch_project(
+            project_key="PROJ",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+            since_timestamp='bad" OR "1"="1',
+        )
+        assert "Error" in result
 
 
 def test_jira_tools_collection():

--- a/tests/unit/tools/test_jira_watch_tool.py
+++ b/tests/unit/tools/test_jira_watch_tool.py
@@ -1,7 +1,12 @@
 """Unit tests for JIRA watch tools."""
 
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
-from unittest.mock import Mock, patch
+
+# Optional dependency — stub so @patch("jira.JIRA") resolves in CI without jira installed.
+sys.modules.setdefault("jira", MagicMock())
 
 from praisonai_tools.tools.jira_watch_tool import (
     jira_watch_issue,

--- a/tests/unit/tools/test_jira_watch_tool.py
+++ b/tests/unit/tools/test_jira_watch_tool.py
@@ -8,7 +8,7 @@ import pytest
 # Optional dependency — stub so @patch("jira.JIRA") resolves in CI without jira installed.
 sys.modules.setdefault("jira", MagicMock())
 
-from praisonai_tools.tools.jira_watch_tool import (
+from praisonai_tools.tools.jira_watch_tool import (  # noqa: E402
     jira_watch_issue,
     jira_watch_project,
     jira_get_issue_info,

--- a/tests/unit/tools/test_jira_watch_tool.py
+++ b/tests/unit/tools/test_jira_watch_tool.py
@@ -52,7 +52,8 @@ class TestJIRAConnection:
         with pytest.raises(ValueError, match="JIRA authentication required"):
             _get_jira_connection(url="https://test.atlassian.net")
 
-    def test_connection_missing_url(self):
+    def test_connection_missing_url(self, monkeypatch):
+        monkeypatch.delenv("JIRA_URL", raising=False)
         with pytest.raises(ValueError, match="JIRA URL is required"):
             _get_jira_connection(email="test@example.com", token="token")
 
@@ -240,6 +241,42 @@ class TestJIRAWatchSinceTimestamp:
         )
         assert "changes detected" in result
         assert "PROJ-123" in result
+
+    @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
+    def test_watch_issue_reports_all_in_window_changes(self, mock_connection):
+        mock_jira = Mock()
+        mock_connection.return_value = mock_jira
+        mock_issue = Mock()
+        mock_issue.fields.updated = "2024-06-15T10:00:00+00:00"
+        mock_issue.fields.status.name = "Done"
+        mock_issue.fields.summary = "Test issue"
+        mock_issue.fields.assignee.displayName = "John Doe"
+        mock_issue.fields.priority.name = "High"
+
+        histories = []
+        for idx in range(5):
+            hist = Mock()
+            hist.created = f"2024-06-1{idx}T10:00:00+00:00"
+            hist.author.displayName = "Editor"
+            item = Mock()
+            item.field = f"field{idx}"
+            item.fromString = "old"
+            item.toString = "new"
+            hist.items = [item]
+            histories.append(hist)
+        mock_issue.changelog.histories = histories
+        mock_jira.issue.return_value = mock_issue
+        mock_jira.comments.return_value = []
+
+        result = jira_watch_issue(
+            issue_key="PROJ-123",
+            url="https://test.atlassian.net",
+            email="test@example.com",
+            token="test_token",
+            since_timestamp="2024-01-01T00:00:00Z",
+        )
+        for idx in range(5):
+            assert f"field{idx}" in result
 
     @patch("praisonai_tools.tools.jira_watch_tool._get_jira_connection")
     def test_watch_project_since_timestamp_no_injection(self, mock_connection):


### PR DESCRIPTION
## summary

Ports JIRA watch/monitor tools from PraisonAI PR #1875 into PraisonAI-Tools (correct layer for external integrations).

## What's added

- `jira_watch_issue` — monitor a specific issue for changes since a timestamp
- `jira_watch_project` — monitor a project for new/updated issues
- `jira_get_issue_info` — detailed issue information
- `jira_search_issues` — JQL search with agent-friendly formatted output
- `jira_tools()` — convenience collection for agent registration
- Unit tests and `examples/jira_watch_example.py`

## Auth

Supports cloud (`JIRA_EMAIL` + `JIRA_API_TOKEN`) and server (`JIRA_USERNAME` + `JIRA_API_TOKEN`), with `JIRA_URL` env fallback.

## Test plan

- [x] `pytest tests/unit/tools/test_jira_watch_tool.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JIRA tools for watching specific issues or projects, detecting changes since a given timestamp, retrieving issue details, and searching issues via JQL.
  * Introduced an interactive Python CLI example demonstrating how to configure and use the JIRA tools with an agent.

* **Tests**
  * Expanded unit test coverage for JIRA validation, watch behavior (including change/no-change cases), and error handling to ensure consistent outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->