### PR TITLE
fix(merge-gate): clear stale conflict block when PR is mergeable

### DIFF
--- a/.github/scripts/merge-gate-selftest.js
+++ b/.github/scripts/merge-gate-selftest.js
@@ -212,6 +212,33 @@ assert('conflict still blocks without FINAL on HEAD', mg.hasRecentConflictCommen
   [conflictTrigger, rebaseDone],
   headAfterRebase
 ));
+assert(
+  'CLEAN + head after conflict clears without completion comment',
+  !mg.hasRecentConflictComment([conflictTrigger], headAfterRebase, 'CLEAN')
+);
+assert(
+  'UNSTABLE + head after conflict clears without completion comment',
+  !mg.hasRecentConflictComment([conflictTrigger], headAfterRebase, 'UNSTABLE')
+);
+assert(
+  'DIRTY still blocks even with head after conflict',
+  mg.hasRecentConflictComment([conflictTrigger], headAfterRebase, 'DIRTY')
+);
+assert(
+  'owner rebase-complete comment clears conflict',
+  !mg.hasRecentConflictComment(
+    [
+      conflictTrigger,
+      {
+        user: { login: 'MervinPraison' },
+        body: '**Rebase complete** — conflicts resolved.',
+        created_at: conflictIso(-29 * 60 * 1000),
+      },
+      finalAfterRebase,
+    ],
+    headAfterRebase
+  )
+);
 
 // Tests heuristic
 assert('product code without tests', mg.missingTestsReason([{ filename: productSample, additions: 3 }]) !== null);

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -135,14 +135,18 @@ function hasRecentConflictComment(comments, headPushedAt = null, mergeStateStatu
   // GitHub mergeable (CLEAN/UNSTABLE) and HEAD pushed after the conflict trigger → resolved
   const status = String(mergeStateStatus || '').toUpperCase();
   if (headPushedAt && ALLOWED_MERGE_STATES.has(status)) {
+    // conflictTriggers is guaranteed non-empty here (hasRecentTrigger is true above);
+    // the null seed keeps reduce() safe if that invariant ever changes.
     const conflictTriggers = comments.filter(isConflictRebaseTriggerComment);
-    if (conflictTriggers.length > 0) {
-      const latestConflict = conflictTriggers.reduce((a, b) =>
-        new Date(a.created_at) > new Date(b.created_at) ? a : b
-      );
-      if (new Date(headPushedAt).getTime() > new Date(latestConflict.created_at).getTime()) {
-        return false;
-      }
+    const latestConflict = conflictTriggers.reduce(
+      (a, b) => (a && new Date(a.created_at) > new Date(b.created_at) ? a : b),
+      null
+    );
+    if (
+      latestConflict &&
+      new Date(headPushedAt).getTime() > new Date(latestConflict.created_at).getTime()
+    ) {
+      return false;
     }
   }
   return true;

--- a/.github/scripts/merge-gate.js
+++ b/.github/scripts/merge-gate.js
@@ -89,7 +89,11 @@ function isConflictRebaseTriggerComment(c) {
 
 function isConflictRebaseCompletionComment(c) {
   const login = (c.user?.login || '').toLowerCase();
-  if (!login.includes('praisonai-triage') && !login.includes('github-actions')) return false;
+  const allowed =
+    login.includes('praisonai-triage') ||
+    login.includes('github-actions') ||
+    AUTO_ACTORS.some((a) => a.toLowerCase() === login);
+  if (!allowed) return false;
   const body = (c.body || '').toLowerCase();
   return (
     body.includes('rebase complete') ||
@@ -116,7 +120,7 @@ function conflictRebaseQuiescent(comments, headPushedAt) {
   return finalClaudeCompletedOnSha(comments, headPushedAt);
 }
 
-function hasRecentConflictComment(comments, headPushedAt = null) {
+function hasRecentConflictComment(comments, headPushedAt = null, mergeStateStatus = null) {
   const cutoff = Date.now() - CONFLICT_COOLDOWN_MS;
   const hasRecentTrigger = comments.some((c) => {
     if (!isConflictRebaseTriggerComment(c)) return false;
@@ -126,6 +130,20 @@ function hasRecentConflictComment(comments, headPushedAt = null) {
 
   if (headPushedAt && conflictRebaseQuiescent(comments, headPushedAt)) {
     return false;
+  }
+
+  // GitHub mergeable (CLEAN/UNSTABLE) and HEAD pushed after the conflict trigger → resolved
+  const status = String(mergeStateStatus || '').toUpperCase();
+  if (headPushedAt && ALLOWED_MERGE_STATES.has(status)) {
+    const conflictTriggers = comments.filter(isConflictRebaseTriggerComment);
+    if (conflictTriggers.length > 0) {
+      const latestConflict = conflictTriggers.reduce((a, b) =>
+        new Date(a.created_at) > new Date(b.created_at) ? a : b
+      );
+      if (new Date(headPushedAt).getTime() > new Date(latestConflict.created_at).getTime()) {
+        return false;
+      }
+    }
   }
   return true;
 }
@@ -672,7 +690,7 @@ async function evaluatePipelineQuiescent(github, owner, repo, prNumber, core, op
     reasons.push('fork PR');
   }
 
-  if (hasRecentConflictComment(ctx.comments, ctx.headPushedAt)) {
+  if (hasRecentConflictComment(ctx.comments, ctx.headPushedAt, status)) {
     reasons.push('recent merge-conflict @claude');
   }
   if (!skipRecentClaudeCooldown && hasRecentClaudeTrigger(ctx.comments, 35)) {


### PR DESCRIPTION
## Summary
- Stop blocking auto-merge for 12h on stale `merge-conflict @claude` comments when GitHub already reports CLEAN/UNSTABLE and HEAD was pushed after the conflict trigger
- Accept owner (`MervinPraison`) rebase-complete comments as conflict resolution (not only triage/github-actions bots)
- Extend merge-gate selftest coverage for CLEAN/UNSTABLE/DIRTY and owner completion comments

## Test plan
- [x] `node .github/scripts/merge-gate-selftest.js` passes
- [ ] Merge this PR, then re-run pipeline-status-sync / merge gate on #42, #40, #30
- [ ] Confirm `pipeline/blocked:conflict` clears when mergeable after rebase