### PR TITLE
fix(release): align version with PyPI and skip Release/Bump loops

### DIFF
--- a/.github/workflows/nightly-release-gate.yml
+++ b/.github/workflows/nightly-release-gate.yml
@@ -39,7 +39,9 @@ jobs:
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
-        github.event.workflow_run.event == 'push'
+        github.event.workflow_run.event == 'push' &&
+        !startsWith(github.event.workflow_run.head_commit.message, 'Release v') &&
+        !startsWith(github.event.workflow_run.head_commit.message, 'Bump ')
       )
     runs-on: ubuntu-latest
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "praisonai-tools"
-version = "0.2.29"
+version = "0.2.30"
 description = "Extended tools for PraisonAI Agents"
 authors = [
     {name = "Mervin Praison"}


### PR DESCRIPTION
## Summary
- Sync `pyproject.toml` to **0.2.30** (matches PyPI; unblocks next patch auto-release)
- Skip nightly release gate when CI was triggered by `Release v*` / `Bump ` commits (monorepo parity)
- Environments `pypi-auto` + `pypi` already created on the repo

## Follow-up after merge
- Tag `v0.2.30` on main so path-diff baseline is correct

## Test plan
- [ ] Nightly dry-run skips with clear reason until next package-path change
- [ ] After a real tools change, gate can dispatch `pypi-release` via `pypi-auto`