### PR TITLE
fix(release): stop failing on gitignored uv.lock

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -123,7 +123,7 @@ jobs:
           VERSION: ${{ steps.versions.outputs.new_version }}
         run: |
           TAG="v${VERSION}"
-          git add pyproject.toml uv.lock
+          git add pyproject.toml
           git commit -m "Release ${TAG}" || exit 0
           git tag -f "${TAG}"
           git pull --rebase origin main


### PR DESCRIPTION
## Summary
- `pypi-release.yml` was failing at Commit/tag/push because `uv.lock` is gitignored
- Only `git add pyproject.toml` now (matches intentional ignore)

## Context
Nightly gate correctly dispatched after #48; release run failed before PyPI publish.

## Test plan
- [ ] Re-run or wait for next gate; release should pass Commit/tag/push
- [ ] Tag `v0.2.30` on main so #48 version sync alone does not force `0.2.31`