### PR TITLE
fix(merge-gate): stash gate-config.js with merge-gate.js

### DIFF
--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -252,8 +252,9 @@ jobs:
 
       - name: Stash merge gate helpers
         run: |
-          cp .github/scripts/merge-gate.js /tmp/merge-gate.js
-          mkdir -p /tmp/gh-actions
+          # Keep scripts together so require('./gate-config.js') works from /tmp
+          mkdir -p /tmp/merge-gate-scripts /tmp/gh-actions
+          cp .github/scripts/merge-gate.js .github/scripts/gate-config.js /tmp/merge-gate-scripts/
           cp -R .github/actions/claude-code-action /tmp/gh-actions/
 
       - name: Fetch PR branch
@@ -322,7 +323,7 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const mergeGate = require('/tmp/merge-gate.js');
+            const mergeGate = require('/tmp/merge-gate-scripts/merge-gate.js');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = ${{ matrix.pr_number }};
@@ -361,7 +362,7 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const mergeGate = require('/tmp/merge-gate.js');
+            const mergeGate = require('/tmp/merge-gate-scripts/merge-gate.js');
             const comments = await mergeGate.listAllComments(
               github, context.repo.owner, context.repo.repo, ${{ matrix.pr_number }}
             );


### PR DESCRIPTION
## Summary
- Stash `gate-config.js` alongside `merge-gate.js` so post-assess steps can `require` after PR checkout
- Fixes `Cannot find module './gate-config.js'` that blocked merge-only for #42

## Test plan
- [ ] Merge gate assess + Require Opus verdict step succeeds on a merge-ready PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the merge-gate assessment flow so helper scripts are staged and loaded more reliably during automated checks.
  * Updated script handling to use a dedicated temporary location, reducing the chance of missing or conflicting files during verdict posting and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->