### PR TITLE
fix(video): align motion graphics team tests with hierarchical API

### DIFF
--- a/examples/motion_graphics_example.py
+++ b/examples/motion_graphics_example.py
@@ -194,7 +194,7 @@ def example_team_preset():
         
         print("✓ Motion graphics team created successfully!")
         print(f"  Agents: {[agent.name for agent in team.agents]}")
-        print(f"  Leader: {team.leader.name}")
+        print(f"  Coordinator: {team.agents[0].name}")
         print(f"  Workspace: {team._motion_graphics_workspace}")
         
     except ImportError as e:

--- a/praisonai_tools/video/motion_graphics/team.py
+++ b/praisonai_tools/video/motion_graphics/team.py
@@ -51,6 +51,12 @@ def motion_graphics_team(
         
     Returns:
         AgentTeam configured for motion graphics creation
+
+    Note:
+        The team uses ``process="hierarchical"`` where the ``manager_llm``
+        orchestrates the worker agents at runtime. The coordinator is the
+        semantic leader and is always the first agent (``team.agents[0]``);
+        there is no static ``team.leader`` reference in this mode.
     """
     if AgentTeam is None:
         raise ImportError(

--- a/tests/integration/test_motion_graphics_team.py
+++ b/tests/integration/test_motion_graphics_team.py
@@ -164,8 +164,8 @@ class TestMotionGraphicsTeam:
                 custom_param="test"
             )
             
-            # Check that custom parameters are passed through alongside
-            # the hierarchical process kwargs forwarded by the preset
+            # Hierarchical teams forward process + manager_llm alongside
+            # any user-supplied kwargs, so assert individual entries.
             assert team.kwargs["custom_param"] == "test"
             assert team.kwargs["process"] == "hierarchical"
             assert team.kwargs["manager_llm"] == "gpt-4"
@@ -212,11 +212,11 @@ class TestMotionGraphicsTeam:
     @patch('praisonai_tools.video.motion_graphics.team.search_web', MockSearch())
     @patch('praisonai_tools.video.motion_graphics.team.create_motion_graphics_agent')
     def test_coordinator_is_leader(self, mock_create_agent):
-        """Test that coordinator is the semantic leader (agents[0]).
+        """Test that coordinator is the semantic leader (first agent).
 
         In hierarchical process mode the manager LLM orchestrates workers,
-        so the coordinator is exposed as the first agent rather than via a
-        static ``team.leader`` reference.
+        so the coordinator is the first agent rather than a static
+        ``team.leader`` reference.
         """
         mock_animator = MockAgent(name="animator")
         mock_create_agent.return_value = mock_animator


### PR DESCRIPTION
Fixes #57

## Summary
Three of twelve integration tests in `tests/integration/test_motion_graphics_team.py` failed due to test/API drift with the hierarchical `AgentTeam` pattern (not missing video deps).

- `motion_graphics_team()` builds the coordinator as `agents[0]` and uses `process="hierarchical"` + `manager_llm`; it does not set a static `team.leader`.
- Tests expected `team.leader` populated and `team.kwargs == {"custom_param": "test"}` only.

## Changes (Option A — align tests with hierarchical API)
- `test_team_custom_parameters`: assert individual kwargs (`custom_param`, `process`, `manager_llm`) instead of exact dict equality.
- `test_coordinator_is_leader`: assert coordinator is `team.agents[0]` (semantic leader in hierarchical mode).
- `test_coordinator_instructions`: read coordinator from `team.agents[0]`.
- Documented the hierarchical coordinator pattern in the `motion_graphics_team` docstring.

No production behavior change; only tests + docstring. `praisonaiagents` is not modified (not vendored here).

## Test plan
- [x] `pytest tests/integration/test_motion_graphics_team.py -v` → 12/12 pass

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the coordinator is the semantic leader in hierarchical motion graphics teams and is represented by the first team agent.
  * Updated example output to report the coordinator’s name.
  * Expanded integration test descriptions for clearer guidance on team configuration and leadership behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->