### PR TITLE
feat: source-derive the tool catalogue (fixes #76)

### DIFF
--- a/praisonai_tools/catalogue.py
+++ b/praisonai_tools/catalogue.py
@@ -26,10 +26,19 @@ installed.
 
 from __future__ import annotations
 
+import ast
+import os
 from dataclasses import dataclass, field
-from typing import Tuple
+from functools import lru_cache
+from typing import Dict, Optional, Tuple
 
 ENTRY_POINT_GROUP = "praisonai.tools"
+
+# Directory that holds the first-party ``*_tool.py`` files. The catalogue is
+# derived by scanning this directory, so dropping a new ``*_tool.py`` that
+# defines a ``*Tool`` class makes the tool discoverable with no edits to any
+# hand-maintained list.
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), "tools")
 
 # Map from the module (as recorded in ``_TOOL_MAP``) to the optional-dependency
 # extras required to use tools defined in it. Modules absent from this mapping
@@ -70,8 +79,9 @@ class ToolCatalogueEntry:
 def _summary_for(name: str) -> str:
     """Derive a concise one-line summary for a tool class name.
 
-    We avoid importing the tool (which could pull heavy/optional deps) and
-    instead produce a stable, human-friendly summary from the name itself.
+    Fallback used only when a tool class does not declare a literal
+    ``description``. We avoid importing the tool (which could pull heavy/optional
+    deps) and instead produce a stable, human-friendly summary from the name.
     """
     if name.endswith("Tool"):
         base = name[:-4]
@@ -80,30 +90,113 @@ def _summary_for(name: str) -> str:
     return f"{base} integration tool".strip()
 
 
+def _first_line(text: str) -> str:
+    """Return the first non-empty line of ``text`` (a tool ``description``)."""
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _scan_module(path: str) -> "list[tuple[str, str]]":
+    """AST-scan a ``*_tool.py`` file for ``*Tool`` classes and descriptions.
+
+    Returns a list of ``(class_name, summary)`` tuples. The file is parsed, not
+    imported, so this stays cheap and never triggers optional dependencies.
+    Classes without a literal ``description`` fall back to a name-synthesised
+    summary.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), filename=path)
+    except (OSError, SyntaxError):  # pragma: no cover - defensive
+        return []
+
+    found = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or not node.name.endswith("Tool"):
+            continue
+        description: Optional[str] = None
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Assign):
+                continue
+            targets = [
+                t.id for t in stmt.targets if isinstance(t, ast.Name)
+            ]
+            if "description" in targets and isinstance(stmt.value, ast.Constant):
+                if isinstance(stmt.value.value, str):
+                    description = stmt.value.value
+        summary = _first_line(description) if description else _summary_for(node.name)
+        found.append((node.name, summary or _summary_for(node.name)))
+    return found
+
+
+@lru_cache(maxsize=1)
+def _scan_source_tree() -> "Dict[str, Tuple[str, str]]":
+    """Derive the first-party tool catalogue from the source tree.
+
+    Scans every ``praisonai_tools/tools/*_tool.py`` file for ``*Tool`` classes
+    and returns ``{class_name: (module, summary)}``. Because the mapping is
+    derived from the files that actually exist, phantom names (advertised tools
+    with no file) are impossible by construction, and adding a tool is a single
+    new-file change.
+    """
+    derived: "Dict[str, Tuple[str, str]]" = {}
+    try:
+        filenames = sorted(os.listdir(_TOOLS_DIR))
+    except OSError:  # pragma: no cover - defensive
+        return derived
+
+    for filename in filenames:
+        if not filename.endswith("_tool.py"):
+            continue
+        module = filename[:-3]  # strip ".py"; relative module name within tools
+        path = os.path.join(_TOOLS_DIR, filename)
+        for class_name, summary in _scan_module(path):
+            derived.setdefault(class_name, (module, summary))
+    return derived
+
+
 def _first_party_entries() -> "list[ToolCatalogueEntry]":
     """Build catalogue entries for every first-party tool class.
 
-    The source of truth is ``praisonai_tools.tools._TOOL_MAP`` which maps every
-    public name (both classes and helper functions) to its defining module. We
-    expose only the tool *classes* (names ending in ``Tool``) in the catalogue,
-    since those are what ``agents.yaml`` and the SDK reference.
-    """
-    from praisonai_tools.tools import _TOOL_MAP
+    The catalogue is source-derived: it is built by scanning the actual
+    ``*_tool.py`` files on disk (see ``_scan_source_tree``) rather than a
+    hand-maintained dictionary, so it can never advertise a tool whose file does
+    not exist. Summaries come from each tool's own ``description``.
 
-    entries = []
-    for name, module in sorted(_TOOL_MAP.items()):
-        if not name.endswith("Tool"):
-            continue
-        extras = _MODULE_EXTRAS.get(module, ())
-        entries.append(
-            ToolCatalogueEntry(
-                name=name,
-                module=module,
-                extras=extras,
-                summary=_summary_for(name),
-            )
+    A few tools live in nested packages (e.g. the n8n workflow tool under
+    ``praisonai_tools.n8n``) rather than flat ``*_tool.py`` files; those are
+    still surfaced via ``_TOOL_MAP`` so their public names remain stable.
+    """
+    entries: "Dict[str, ToolCatalogueEntry]" = {}
+
+    for name, (module, summary) in _scan_source_tree().items():
+        entries[name] = ToolCatalogueEntry(
+            name=name,
+            module=module,
+            extras=_MODULE_EXTRAS.get(module, ()),
+            summary=summary,
         )
-    return entries
+
+    # Include tool classes defined outside the flat ``*_tool.py`` layout (e.g.
+    # nested subpackages) that the scan cannot reach, keeping their names stable.
+    try:
+        from praisonai_tools.tools import _TOOL_MAP
+    except Exception:  # pragma: no cover - defensive
+        _TOOL_MAP = {}
+    for name, module in _TOOL_MAP.items():
+        if not name.endswith("Tool") or name in entries:
+            continue
+        entries[name] = ToolCatalogueEntry(
+            name=name,
+            module=module,
+            extras=_MODULE_EXTRAS.get(module, ()),
+            summary=_summary_for(name),
+        )
+
+    return list(entries.values())
 
 
 def _entry_point_entries() -> "list[ToolCatalogueEntry]":

--- a/praisonai_tools/catalogue.py
+++ b/praisonai_tools/catalogue.py
@@ -119,14 +119,22 @@ def _scan_module(path: str) -> "list[tuple[str, str]]":
             continue
         description: Optional[str] = None
         for stmt in node.body:
-            if not isinstance(stmt, ast.Assign):
+            # Accept both plain ``description = "..."`` and annotated
+            # ``description: str = "..."`` class attributes.
+            if isinstance(stmt, ast.Assign):
+                targets = [t.id for t in stmt.targets if isinstance(t, ast.Name)]
+                value = stmt.value
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                targets = [stmt.target.id]
+                value = stmt.value
+            else:
                 continue
-            targets = [
-                t.id for t in stmt.targets if isinstance(t, ast.Name)
-            ]
-            if "description" in targets and isinstance(stmt.value, ast.Constant):
-                if isinstance(stmt.value.value, str):
-                    description = stmt.value.value
+            if (
+                "description" in targets
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                description = value.value
         summary = _first_line(description) if description else _summary_for(node.name)
         found.append((node.name, summary or _summary_for(node.name)))
     return found
@@ -181,13 +189,19 @@ def _first_party_entries() -> "list[ToolCatalogueEntry]":
         )
 
     # Include tool classes defined outside the flat ``*_tool.py`` layout (e.g.
-    # nested subpackages) that the scan cannot reach, keeping their names stable.
+    # nested subpackages such as ``praisonai_tools.n8n``) that the scan cannot
+    # reach, keeping their names stable. Only *nested* (absolute-module) tools
+    # are merged here: flat ``*_tool.py`` classes are already source-derived by
+    # the scan above, so restoring them from ``_TOOL_MAP`` would reintroduce the
+    # hand-maintained bookkeeping this catalogue exists to eliminate.
     try:
         from praisonai_tools.tools import _TOOL_MAP
     except Exception:  # pragma: no cover - defensive
         _TOOL_MAP = {}
     for name, module in _TOOL_MAP.items():
         if not name.endswith("Tool") or name in entries:
+            continue
+        if not module.startswith("praisonai_tools."):
             continue
         entries[name] = ToolCatalogueEntry(
             name=name,

--- a/praisonai_tools/tools/__init__.py
+++ b/praisonai_tools/tools/__init__.py
@@ -566,18 +566,33 @@ _TOOL_MAP = {
 
 # Lazy imports for tools to avoid loading dependencies until needed
 def __getattr__(name):
-    """Lazy load tool classes."""
-    if name in _TOOL_MAP:
-        module_name = _TOOL_MAP[name]
-        from importlib import import_module
-        
+    """Lazy load tool classes.
+
+    Resolution order:
+    1. The explicit ``_TOOL_MAP`` (covers helper functions and tools that live
+       in nested subpackages such as ``praisonai_tools.n8n``).
+    2. A source-derived scan of ``*_tool.py`` files (``catalogue`` module). This
+       means dropping a new ``*_tool.py`` that defines a ``*Tool`` class makes
+       that class importable with no edit to ``_TOOL_MAP``.
+    """
+    from importlib import import_module
+
+    module_name = _TOOL_MAP.get(name)
+    if module_name is None and name.endswith("Tool"):
+        from praisonai_tools.catalogue import _scan_source_tree
+
+        derived = _scan_source_tree().get(name)
+        if derived is not None:
+            module_name = derived[0]
+
+    if module_name is not None:
         # Handle absolute module paths (e.g., praisonai_tools.n8n.n8n_workflow)
         if module_name.startswith("praisonai_tools."):
             module = import_module(module_name)
         else:
             # Handle relative module paths within tools package
             module = import_module(f".{module_name}", __package__)
-        
+
         return getattr(module, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_catalogue_no_phantoms.py
+++ b/tests/test_catalogue_no_phantoms.py
@@ -30,9 +30,17 @@ def _is_missing_optional_dependency(exc: BaseException, tool_module: str) -> boo
     if not isinstance(exc, ModuleNotFoundError):
         return False
     missing = getattr(exc, "name", "") or ""
-    # The tool's own relative module lives under praisonai_tools.tools.
-    own = f"praisonai_tools.tools.{tool_module}"
-    return missing not in (own, tool_module, "praisonai_tools")
+    # ``tool_module`` may be relative (flat ``*_tool.py`` under
+    # ``praisonai_tools.tools``) or already absolute (nested subpackages such as
+    # ``praisonai_tools.n8n.n8n_workflow``). Resolve to the tool's own dotted
+    # module either way so a *missing first-party* module is treated as a
+    # phantom, not an optional dependency.
+    own = (
+        tool_module
+        if tool_module.startswith("praisonai_tools.")
+        else f"praisonai_tools.tools.{tool_module}"
+    )
+    return missing != own and not own.startswith(f"{missing}.")
 
 
 def test_every_catalogue_name_resolves_or_needs_optional_dep():
@@ -81,5 +89,21 @@ def test_summaries_come_from_real_description():
     # not the name-synthesised fallback ("Calculator integration tool").
     calc = entries.get("CalculatorTool")
     assert calc is not None
-    assert calc.summary
+    assert calc.summary == "Perform mathematical calculations."
     assert "integration tool" not in calc.summary
+
+
+def test_annotated_description_summaries_are_extracted():
+    """Tools declaring ``description: str = "..."`` must surface the real text.
+
+    ``CapsuleTool`` and ``NexusPredictionMarketTool`` use annotated assignments;
+    their catalogue summaries must come from the literal, not the name-based
+    fallback.
+    """
+    entries = {e.name: e for e in list_tools()}
+    for name in ("CapsuleTool", "NexusPredictionMarketTool"):
+        entry = entries.get(name)
+        if entry is None:
+            continue
+        assert entry.summary
+        assert "integration tool" not in entry.summary

--- a/tests/test_catalogue_no_phantoms.py
+++ b/tests/test_catalogue_no_phantoms.py
@@ -1,0 +1,85 @@
+"""CI guard: the catalogue must never advertise a phantom tool.
+
+A "phantom" is a tool name surfaced by ``get_tool_names()`` / ``list_tools()``
+whose class cannot be resolved because no implementation file (or class) exists.
+Because the catalogue is now source-derived (see ``praisonai_tools.catalogue``),
+phantoms should be impossible by construction; this test enforces that during
+any future refactor.
+
+Missing *optional dependencies* are explicitly tolerated: a tool whose file and
+class exist but which needs an un-installed extra will raise ``ImportError`` /
+``ModuleNotFoundError`` for the extra, not an ``AttributeError``. Only the
+latter (name resolves to nothing) counts as a phantom.
+"""
+
+import importlib
+
+import praisonai_tools
+from praisonai_tools import get_tool_names, list_tools
+from praisonai_tools.catalogue import _scan_source_tree
+
+
+def _is_missing_optional_dependency(exc: BaseException, tool_module: str) -> bool:
+    """True if the import failure is due to a missing *optional* dependency.
+
+    A missing optional dependency raises ``ModuleNotFoundError`` for a module
+    that is *not* the tool's own module. If the tool's own file were missing the
+    name would simply not resolve (``AttributeError``) rather than importing and
+    then failing on a third-party import.
+    """
+    if not isinstance(exc, ModuleNotFoundError):
+        return False
+    missing = getattr(exc, "name", "") or ""
+    # The tool's own relative module lives under praisonai_tools.tools.
+    own = f"praisonai_tools.tools.{tool_module}"
+    return missing not in (own, tool_module, "praisonai_tools")
+
+
+def test_every_catalogue_name_resolves_or_needs_optional_dep():
+    entries = {e.name: e for e in list_tools()}
+    phantoms = []
+    for name in sorted(get_tool_names()):
+        module = entries.get(name).module if name in entries else ""
+        try:
+            getattr(praisonai_tools, name)
+        except AttributeError as exc:
+            phantoms.append((name, module, repr(exc)))
+        except Exception as exc:  # ImportError / ModuleNotFoundError, etc.
+            if not _is_missing_optional_dependency(exc, module):
+                phantoms.append((name, module, repr(exc)))
+    assert not phantoms, f"catalogue advertises unresolvable (phantom) tools: {phantoms}"
+
+
+def test_no_phantom_modules_in_scan():
+    """Every source-derived tool maps to a file that actually exists on disk."""
+    import os
+
+    tools_dir = os.path.join(os.path.dirname(praisonai_tools.__file__), "tools")
+    for name, (module, _summary) in _scan_source_tree().items():
+        path = os.path.join(tools_dir, f"{module}.py")
+        assert os.path.isfile(path), f"{name} maps to missing file {module}.py"
+
+
+def test_dropping_a_tool_file_is_auto_discovered():
+    """Files on disk defining a *Tool class are catalogued without _TOOL_MAP edits.
+
+    Guards the core promise of the issue: adding a tool is a single-file change.
+    ``ClaudeMemoryTool``/``CrowPayTool``/``NightmarketTool`` exist on disk but
+    were historically absent from ``_TOOL_MAP``; they must still be discoverable.
+    """
+    names = get_tool_names()
+    for expected in ("ClaudeMemoryTool", "CrowPayTool", "NightmarketTool"):
+        # Only assert for the ones whose files are present in this checkout.
+        derived = _scan_source_tree()
+        if expected in derived:
+            assert expected in names, f"{expected} exists on disk but is not catalogued"
+
+
+def test_summaries_come_from_real_description():
+    entries = {e.name: e for e in list_tools()}
+    # CalculatorTool declares a literal description; the summary must match it,
+    # not the name-synthesised fallback ("Calculator integration tool").
+    calc = entries.get("CalculatorTool")
+    assert calc is not None
+    assert calc.summary
+    assert "integration tool" not in calc.summary


### PR DESCRIPTION
Fixes #76

## Summary

Derives the first-party tool catalogue from the **source tree** instead of the hand-maintained `_TOOL_MAP`, so:
- Adding a tool becomes a **single-file change** (drop a `*_tool.py` with a `*Tool` class).
- Phantom names (advertised tools with no file) are **impossible by construction**.
- Catalogue summaries come from each tool's **real `description`**, not name-synthesis.

## Changes

- **`praisonai_tools/catalogue.py`** — `_first_party_entries()` now builds from `_scan_source_tree()`, an **AST scan** of `praisonai_tools/tools/*_tool.py` that extracts `*Tool` class names and their literal `description`. The scan parses (never imports) files, so `import praisonai_tools` and `list_tools()` stay cheap and require no optional deps. Tools in nested subpackages (e.g. n8n) are still merged from `_TOOL_MAP` so their names stay stable.
- **`praisonai_tools/tools/__init__.py`** — lazy `__getattr__` now falls back to the source-derived scan, so a dropped `*_tool.py` is importable with no `_TOOL_MAP` edit. This auto-discovers `ClaudeMemoryTool`, `CrowPayTool`, `NightmarketTool` (files that existed on disk but were missing from `_TOOL_MAP` — the inverse drift).
- **`tests/test_catalogue_no_phantoms.py`** — CI guard asserting every catalogue name resolves (tolerating only missing *optional* deps), maps to a real file, auto-discovery works, and summaries come from real descriptions.

## Notes on the issue's phantom examples

The specific names cited (`giphy_tool`, `bigquery_tool`, `zep_tool`, `higgsfield_tool`) have since gained files, so there were **0 live resolution failures** at the time of this change. The remaining problems — drift-prone quadruple bookkeeping, name-synthesised summaries, and no guard — are what this PR fixes, and the new CI test prevents phantoms from reappearing.

## Validation

- `list_tools()` returns 145 entries and imports **zero** tool modules (verified dependency-free).
- 0 phantoms across the whole catalogue.
- `tests/test_catalogue.py` (13) + `tests/test_catalogue_no_phantoms.py` + `tests/test_tools.py`/`test_base.py` (77) all pass.
- Existing public import names (`from praisonai_tools import XTool`) remain stable.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool discovery now automatically identifies first-party tools from available source files.
  * Tool summaries are generated from declared descriptions, with sensible fallbacks when needed.
  * Tools can be loaded on demand, including tools in nested packages.

* **Bug Fixes**
  * Prevented unavailable or phantom tools from appearing in the catalogue.
  * Improved compatibility when optional dependencies are not installed.

* **Tests**
  * Added coverage to verify tool discovery, catalogue accuracy, and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->