### PR TITLE
fix: silence benign 'Registry is None' WARNING spam on bare import

### DIFF
--- a/praisonai_tools/tools/decorator.py
+++ b/praisonai_tools/tools/decorator.py
@@ -17,6 +17,49 @@ Usage:
         return [...]
 """
 
+import logging as _logging
+
+
+class _SuppressRegistryNoneWarning(_logging.Filter):
+    """Drop the benign "Registry is None for tool …" WARNING.
+
+    ``praisonaiagents.tools.decorator`` logs a WARNING for every ``@tool``
+    decorated function when no global tool registry exists yet. On a bare
+    ``import`` (library use, scripts, pytest collection) that is the normal
+    state, not an anomaly - registration happens lazily once an agent/registry
+    comes up. The message fires once per decorated function, so the noise scales
+    with the tool catalogue and is the first thing every consumer sees. We drop
+    only that specific record and leave all other logging untouched.
+    """
+
+    def filter(self, record: _logging.LogRecord) -> bool:
+        return not record.getMessage().startswith("Registry is None for tool")
+
+
+def _silence_registry_none_warning() -> None:
+    """Install the filter so bare imports stay quiet at default log levels.
+
+    The upstream code emits the record via ``logging.warning`` (the root
+    logger), and ``praisonaiagents`` configures a handler on the root logger, so
+    the record surfaces there. We attach the filter to the root logger and its
+    handlers - it only drops the single "Registry is None for tool …" record and
+    passes everything else through, so user logging is unaffected. The proper fix
+    (defer registration / downgrade to debug) belongs in praisonaiagents core.
+    """
+    filt = _SuppressRegistryNoneWarning()
+    root = _logging.getLogger()
+    root.addFilter(filt)
+    for handler in root.handlers:
+        handler.addFilter(filt)
+
+
+# ``praisonaiagents`` configures root logging on import; do it first so its
+# handlers exist, then attach the filter before any module-level ``@tool``
+# decoration runs.
+import praisonaiagents  # noqa: F401  (import for logging side effects only)
+
+_silence_registry_none_warning()
+
 # Import from praisonaiagents - single source of truth
 from praisonaiagents.tools.decorator import (
     tool,

--- a/praisonai_tools/tools/decorator.py
+++ b/praisonai_tools/tools/decorator.py
@@ -56,12 +56,12 @@ def _silence_registry_none_warning() -> None:
 # ``praisonaiagents`` configures root logging on import; do it first so its
 # handlers exist, then attach the filter before any module-level ``@tool``
 # decoration runs.
-import praisonaiagents  # noqa: F401  (import for logging side effects only)
+import praisonaiagents  # noqa: E402,F401  (import for logging side effects only)
 
 _silence_registry_none_warning()
 
 # Import from praisonaiagents - single source of truth
-from praisonaiagents.tools.decorator import (
+from praisonaiagents.tools.decorator import (  # noqa: E402
     tool,
     FunctionTool,
     is_tool,


### PR DESCRIPTION
Fixes #80

## Summary

Importing `praisonai_tools` tools (e.g. `praisonai_tools.registry_proxy`) outside a running agent context emitted one `WARNING` per `@tool`-decorated function:

```
decorator.py:351 WARNING Registry is None for tool registry_search
decorator.py:351 WARNING Registry is None for tool registry_describe
decorator.py:351 WARNING Registry is None for tool registry_call
```

On a bare import (library use, scripts, pytest collection) that is the normal state, not an anomaly, so it polluted logs/CI for every consumer and scaled with the tool catalogue.

## Cause

The WARNING is emitted from `praisonaiagents.tools.decorator:351` (external, not vendored here) via `logging.warning(...)`, which surfaces on the root logger that `praisonaiagents` configures on import.

## Change

`praisonai_tools/tools/decorator.py` now installs a targeted `logging.Filter` on the root logger and its handlers that drops **only** the `"Registry is None for tool …"` record and passes all other logging through untouched. This runs before any module-level `@tool` decoration, so consumers see no noise at default log levels. Registration behaviour is unchanged.

The definitive fix (defer registration / downgrade to `debug`) belongs in **PraisonAI core** (`praisonaiagents`); per the layer rules this repo cannot change that package, so this applies a minimal, non-invasive suppression in the Tools layer.

## Acceptance

- `python -c "import praisonai_tools.registry_proxy"` produces **no** WARNING output at default logging. ✅
- Unrelated warnings still appear (filter is message-specific). ✅
- Existing decorated-function tests pass: `23 passed, 1 skipped`. ✅

## Test plan
- [x] `python -c "import praisonai_tools.registry_proxy"` is silent
- [x] `python -m pytest tests/test_registry_proxy.py -q`
- [x] Verified an unrelated `logging.warning` still emits

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced harmless warning messages appearing during tool imports.
  * Preserved other warning and error messages for normal visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->