### PR TITLE
feat: registry_proxy wire-compatibility — configurable auth header and price-field tolerance

### DIFF
--- a/docs/registry_proxy_integration.md
+++ b/docs/registry_proxy_integration.md
@@ -31,6 +31,10 @@ pip install "praisonai-tools[registry-proxy]"
 ```bash
 export TOOL_PROXY_URL="https://your-registry.example.com"   # or a self-hosted instance
 export TOOL_PROXY_TOKEN="your-proxy-token"
+# Optional: override the auth header for registries that expect a custom header.
+# Default is "Authorization" (sent as "Bearer <token>"); any other name (e.g.
+# "X-Treg-Token") sends the raw token in that header.
+export TOOL_PROXY_AUTH_HEADER="Authorization"
 ```
 
 ```python

--- a/praisonai_tools/registry_proxy/registry_proxy.py
+++ b/praisonai_tools/registry_proxy/registry_proxy.py
@@ -51,6 +51,7 @@ class RegistryProxyTool(BaseTool):
         timeout: float = 60.0,
         max_cost_per_call: Optional[float] = None,
         max_session_spend: Optional[float] = None,
+        auth_header: Optional[str] = None,
     ):
         url_from_env = proxy_url is None
         self.proxy_url = (proxy_url or os.getenv("TOOL_PROXY_URL") or "").rstrip("/")
@@ -64,6 +65,10 @@ class RegistryProxyTool(BaseTool):
             self.token = os.getenv("TOOL_PROXY_TOKEN")
         else:
             self.token = None
+        # Auth header is configurable for wire-compatibility with different
+        # registry deployments. Default ``Authorization`` sends ``Bearer {token}``;
+        # a custom header name (e.g. ``X-Treg-Token``) sends the raw token instead.
+        self.auth_header = auth_header or os.getenv("TOOL_PROXY_AUTH_HEADER") or "Authorization"
         self.timeout = timeout
         self.max_cost_per_call = max_cost_per_call
         self.max_session_spend = max_session_spend
@@ -99,7 +104,10 @@ class RegistryProxyTool(BaseTool):
     def _headers(self) -> Dict[str, str]:
         headers = {"Content-Type": "application/json"}
         if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
+            if self.auth_header.lower() == "authorization":
+                headers[self.auth_header] = f"Bearer {self.token}"
+            else:
+                headers[self.auth_header] = self.token
         return headers
 
     def _require_config(self) -> Optional[Dict[str, Any]]:
@@ -178,6 +186,20 @@ class RegistryProxyTool(BaseTool):
             logger.error("registry describe error: %s", exc)
             return {"error": str(exc)}
 
+    @staticmethod
+    def _extract_price(data: Any) -> Any:
+        """Read a price from a response, tolerating field-name variation.
+
+        Tries ``price_per_call`` then ``price`` then ``cost`` so the budget check
+        and spend recording share the same tolerance against the live schema.
+        """
+        if not isinstance(data, dict):
+            return None
+        for key in ("price_per_call", "price", "cost"):
+            if key in data:
+                return data[key]
+        return None
+
     def _check_budget(self, tool_id: str):
         """Deny + report if a configured spend guard would be exceeded.
 
@@ -190,7 +212,10 @@ class RegistryProxyTool(BaseTool):
         described = self.describe(tool_id)
         if isinstance(described, dict) and "error" in described:
             return described, None
-        price = described.get("price_per_call") if isinstance(described, dict) else None
+        # Accept the same price field names tolerated by spend recording so the
+        # budget check does not fail closed on a field-name mismatch against the
+        # live registry schema (``price_per_call`` -> ``price`` -> ``cost``).
+        price = self._extract_price(described)
         try:
             price = float(price)
         except (TypeError, ValueError):
@@ -198,8 +223,8 @@ class RegistryProxyTool(BaseTool):
             # validated, so we cannot guarantee the budget - deny the call.
             return {
                 "error": (
-                    "Denied: price_per_call is missing or invalid, cannot enforce "
-                    "the configured spend guard."
+                    "Denied: price (price_per_call/price/cost) is missing or "
+                    "invalid, cannot enforce the configured spend guard."
                 )
             }, None
         if self.max_cost_per_call is not None and price > self.max_cost_per_call:
@@ -256,9 +281,7 @@ class RegistryProxyTool(BaseTool):
         # Record cumulative spend. Prefer the charge reported by the proxy; fall
         # back to the price quoted at budget-check time so the session budget
         # still accrues when the response omits cost fields.
-        charged = None
-        if isinstance(result, dict):
-            charged = result.get("price_per_call", result.get("cost"))
+        charged = self._extract_price(result)
         try:
             self._session_spend += float(charged)
         except (TypeError, ValueError):
@@ -272,6 +295,7 @@ def registry_search(
     query: str,
     proxy_url: Optional[str] = None,
     token: Optional[str] = None,
+    auth_header: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Search the connected tool registry by capability.
 
@@ -282,11 +306,15 @@ def registry_search(
         query: Capability to search for.
         proxy_url: Registry base URL (defaults to TOOL_PROXY_URL env var).
         token: Proxy token (defaults to TOOL_PROXY_TOKEN env var).
+        auth_header: Auth header name (defaults to TOOL_PROXY_AUTH_HEADER env var,
+            then ``Authorization``).
 
     Returns:
         Dict with catalogue matches, or ``{"error": ...}`` on failure.
     """
-    return RegistryProxyTool(proxy_url=proxy_url, token=token).search(query)
+    return RegistryProxyTool(
+        proxy_url=proxy_url, token=token, auth_header=auth_header
+    ).search(query)
 
 
 @tool
@@ -294,6 +322,7 @@ def registry_describe(
     tool_id: str,
     proxy_url: Optional[str] = None,
     token: Optional[str] = None,
+    auth_header: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Describe one registry catalogue entry.
 
@@ -304,11 +333,15 @@ def registry_describe(
         tool_id: Catalogue entry identifier (from ``registry_search``).
         proxy_url: Registry base URL (defaults to TOOL_PROXY_URL env var).
         token: Proxy token (defaults to TOOL_PROXY_TOKEN env var).
+        auth_header: Auth header name (defaults to TOOL_PROXY_AUTH_HEADER env var,
+            then ``Authorization``).
 
     Returns:
         Dict describing the entry, or ``{"error": ...}`` on failure.
     """
-    return RegistryProxyTool(proxy_url=proxy_url, token=token).describe(tool_id)
+    return RegistryProxyTool(
+        proxy_url=proxy_url, token=token, auth_header=auth_header
+    ).describe(tool_id)
 
 
 @tool
@@ -319,6 +352,7 @@ def registry_call(
     token: Optional[str] = None,
     max_cost_per_call: Optional[float] = None,
     max_session_spend: Optional[float] = None,
+    auth_header: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Invoke a registry endpoint through the proxy.
 
@@ -333,6 +367,9 @@ def registry_call(
         token: Proxy token (defaults to TOOL_PROXY_TOKEN env var).
         max_cost_per_call: Deny the call if its price exceeds this value.
         max_session_spend: Deny the call if it would push cumulative spend past this value.
+        auth_header: Auth header name (defaults to TOOL_PROXY_AUTH_HEADER env var,
+            then ``Authorization``). ``Authorization`` sends ``Bearer {token}``;
+            any other name (e.g. ``X-Treg-Token``) sends the raw token.
 
     Returns:
         Dict with the endpoint response, or ``{"error": ...}`` on failure/denial.
@@ -342,4 +379,5 @@ def registry_call(
         token=token,
         max_cost_per_call=max_cost_per_call,
         max_session_spend=max_session_spend,
+        auth_header=auth_header,
     ).call(tool_id, params)

--- a/tests/test_registry_proxy.py
+++ b/tests/test_registry_proxy.py
@@ -84,6 +84,36 @@ class TestConfiguration:
             assert tool._headers()["Authorization"] == "Bearer secret-token"
 
 
+class TestAuthHeader:
+    def test_auth_header_configurable(self):
+        """Default sends Bearer; a custom header name sends the raw token."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        default = RegistryProxyTool(proxy_url="https://r.example.com", token="tok")
+        assert default._headers()["Authorization"] == "Bearer tok"
+        assert "X-Treg-Token" not in default._headers()
+
+        custom = RegistryProxyTool(
+            proxy_url="https://r.example.com", token="tok", auth_header="X-Treg-Token"
+        )
+        headers = custom._headers()
+        assert headers["X-Treg-Token"] == "tok"
+        assert "Authorization" not in headers
+
+    def test_auth_header_from_env(self):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        with patch.dict(os.environ, {
+            "TOOL_PROXY_URL": "https://trusted.example.com",
+            "TOOL_PROXY_TOKEN": "secret-token",
+            "TOOL_PROXY_AUTH_HEADER": "X-Treg-Token",
+        }):
+            tool = RegistryProxyTool()
+            headers = tool._headers()
+            assert headers["X-Treg-Token"] == "secret-token"
+            assert "Authorization" not in headers
+
+
 class TestSearch:
     def test_search_success(self, mock_httpx):
         from praisonai_tools.registry_proxy import RegistryProxyTool
@@ -277,6 +307,27 @@ class TestSpendGuards:
         assert result["data"] == "ok"
         assert tool._session_spend == pytest.approx(0.05)
 
+    @pytest.mark.parametrize("field", ["price_per_call", "price", "cost"])
+    def test_budget_check_accepts_price_and_cost_fields(self, mock_httpx, field):
+        """Budget check tolerates price_per_call/price/cost, matching recording."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {"id": "seo.backlinks", field: 0.05}
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": "ok", field: 0.05}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = describe_resp
+        client.post.return_value = call_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", max_session_spend=1.0)
+        result = tool.call("seo.backlinks", {})
+        assert result["data"] == "ok"
+        assert tool._session_spend == pytest.approx(0.05)
+
     def test_missing_price_fails_closed(self, mock_httpx):
         from praisonai_tools.registry_proxy import RegistryProxyTool
 
@@ -332,7 +383,9 @@ class TestDecoratedFunctions:
         mock_cls.return_value = instance
 
         registry_search("q", proxy_url="https://r", token="t")
-        mock_cls.assert_called_once_with(proxy_url="https://r", token="t")
+        mock_cls.assert_called_once_with(
+            proxy_url="https://r", token="t", auth_header=None
+        )
         instance.search.assert_called_once_with("q")
 
     @patch("praisonai_tools.registry_proxy.registry_proxy.RegistryProxyTool")
@@ -356,6 +409,7 @@ class TestDecoratedFunctions:
             token="t",
             max_cost_per_call=0.1,
             max_session_spend=1.0,
+            auth_header=None,
         )
         instance.call.assert_called_once_with("seo.backlinks", {"domain": "x"})
 


### PR DESCRIPTION
Fixes #79

## Summary

Addresses two wire-compatibility risks in the `registry_proxy` connector that the mock-based unit suite could not catch against the live registry service.

### 1. Configurable auth header
- New `TOOL_PROXY_AUTH_HEADER` env var / `auth_header` param.
- Default `Authorization` sends `Bearer {token}` (unchanged behaviour).
- A custom header name (e.g. `X-Treg-Token`) sends the **raw token** in that header, matching the hosted registry's documented call surface.
- Exposed on `registry_search`, `registry_describe`, `registry_call`.

### 2. Price-field tolerance harmonised
- Budget check (`_check_budget`) now accepts `price_per_call` → `price` → `cost`, the **same tolerance** as spend recording, via a shared `_extract_price` helper.
- Still **fails closed** when no price field parses (safety posture unchanged).

## Tests
- `test_auth_header_configurable` + `test_auth_header_from_env`
- `test_budget_check_accepts_price_and_cost_fields` (parametrized over the three field names)
- Existing `test_missing_price_fails_closed`, token-exfiltration guard, and spend-guard tests unchanged.
- Updated two constructor-kwarg assertions for the new `auth_header` param.

Result: **28 passed, 1 skipped** (gated `test_live_smoke`).

The exfiltration guard and fail-closed budget behaviour are preserved and not weakened.

Generated with [Claude Code](https://claude.ai/code)