### PR TITLE
fix: registry_proxy describe path + HTTP method support

### DIFF
--- a/docs/registry_proxy_integration.md
+++ b/docs/registry_proxy_integration.md
@@ -82,7 +82,11 @@ The registry enforces each endpoint's declared HTTP method on `/call/{id}`.
 `registry_call` derives the method automatically from `registry_describe`
 (the endpoint doc carries `method`): `GET` endpoints send `params` as the query
 string, `POST`/`PUT` send them as a JSON body. Pass `method="GET"` explicitly to
-skip the describe lookup when you already know the method.
+skip the describe lookup when you already know the method. Only the standard
+`GET`/`POST`/`PUT`/`PATCH`/`DELETE` verbs are accepted; any other value (e.g. a
+mislabelled endpoint doc) is rejected as a tool-result error before any request.
+`tool_id` is URL-encoded before being placed in the describe/call route, so it
+cannot alter the requested path.
 
 ## Passthrough-URL calls
 

--- a/docs/registry_proxy_integration.md
+++ b/docs/registry_proxy_integration.md
@@ -35,6 +35,9 @@ export TOOL_PROXY_TOKEN="your-proxy-token"
 # Default is "Authorization" (sent as "Bearer <token>"); any other name (e.g.
 # "X-Treg-Token") sends the raw token in that header.
 export TOOL_PROXY_AUTH_HEADER="Authorization"
+# Optional: override the describe route for registries with a different layout.
+# Must contain "{tool_id}"; defaults to the live registry route below.
+export TOOL_PROXY_DESCRIBE_PATH="/catalog/endpoints/{tool_id}"
 ```
 
 ```python
@@ -72,6 +75,21 @@ vendor-specific configuration. Guards **fail closed**: if a budget is set but
 the price cannot be validated, the call is denied. Cumulative `max_session_spend`
 persists across separate `registry_call` invocations within the same process,
 scoped per `(proxy_url, token)` so distinct accounts never share a budget.
+
+## HTTP methods
+
+The registry enforces each endpoint's declared HTTP method on `/call/{id}`.
+`registry_call` derives the method automatically from `registry_describe`
+(the endpoint doc carries `method`): `GET` endpoints send `params` as the query
+string, `POST`/`PUT` send them as a JSON body. Pass `method="GET"` explicitly to
+skip the describe lookup when you already know the method.
+
+## Passthrough-URL calls
+
+Passthrough-URL calls require the upstream to be **registered on the registry
+first**. Loopback/private upstreams (e.g. `127.0.0.1`, RFC-1918 addresses) are
+**refused by the registry's SSRF guard by design** — the base URL must be a
+public `http(s)` address. This is registry-side policy, not a connector setting.
 
 ## Credential safety
 

--- a/praisonai_tools/registry_proxy/registry_proxy.py
+++ b/praisonai_tools/registry_proxy/registry_proxy.py
@@ -52,6 +52,7 @@ class RegistryProxyTool(BaseTool):
         max_cost_per_call: Optional[float] = None,
         max_session_spend: Optional[float] = None,
         auth_header: Optional[str] = None,
+        describe_path: Optional[str] = None,
     ):
         url_from_env = proxy_url is None
         self.proxy_url = (proxy_url or os.getenv("TOOL_PROXY_URL") or "").rstrip("/")
@@ -69,6 +70,14 @@ class RegistryProxyTool(BaseTool):
         # registry deployments. Default ``Authorization`` sends ``Bearer {token}``;
         # a custom header name (e.g. ``X-Treg-Token``) sends the raw token instead.
         self.auth_header = auth_header or os.getenv("TOOL_PROXY_AUTH_HEADER") or "Authorization"
+        # The describe path template is configurable for wire-compatibility with
+        # different registry deployments. It must contain ``{tool_id}``; the
+        # default mirrors the live registry route (``/catalog/endpoints/{id}``).
+        self.describe_path = (
+            describe_path
+            or os.getenv("TOOL_PROXY_DESCRIBE_PATH")
+            or "/catalog/endpoints/{tool_id}"
+        )
         self.timeout = timeout
         self.max_cost_per_call = max_cost_per_call
         self.max_session_spend = max_session_spend
@@ -98,7 +107,11 @@ class RegistryProxyTool(BaseTool):
         if action == "describe":
             return self.describe(kwargs.get("tool_id", ""))
         if action == "call":
-            return self.call(kwargs.get("tool_id", ""), kwargs.get("params"))
+            return self.call(
+                kwargs.get("tool_id", ""),
+                kwargs.get("params"),
+                kwargs.get("method"),
+            )
         return {"error": f"Unknown action '{action}'. Use search, describe or call."}
 
     def _headers(self) -> Dict[str, str]:
@@ -170,10 +183,13 @@ class RegistryProxyTool(BaseTool):
             import httpx
         except ImportError:
             return {"error": _INSTALL_HINT}
+        path = self.describe_path.format(tool_id=tool_id)
+        if not path.startswith("/"):
+            path = "/" + path
         try:
             with httpx.Client(timeout=self.timeout) as client:
                 response = client.get(
-                    f"{self.proxy_url}/catalog/{tool_id}",
+                    f"{self.proxy_url}{path}",
                     headers=self._headers(),
                 )
                 response.raise_for_status()
@@ -185,6 +201,20 @@ class RegistryProxyTool(BaseTool):
         except Exception as exc:  # noqa: BLE001 - surface as tool-result error
             logger.error("registry describe error: %s", exc)
             return {"error": str(exc)}
+
+    @staticmethod
+    def _extract_method(data: Any) -> Optional[str]:
+        """Read the HTTP method from a describe response, if present.
+
+        The live registry's endpoint doc carries ``method: "GET"`` (or POST/PUT);
+        the registry enforces the declared method on ``/call/{id}``.
+        """
+        if not isinstance(data, dict):
+            return None
+        method = data.get("method")
+        if isinstance(method, str) and method.strip():
+            return method.strip().upper()
+        return None
 
     @staticmethod
     def _extract_price(data: Any) -> Any:
@@ -203,15 +233,18 @@ class RegistryProxyTool(BaseTool):
     def _check_budget(self, tool_id: str):
         """Deny + report if a configured spend guard would be exceeded.
 
-        Returns ``(denial, price)``: ``denial`` is a ``{"error": ...}`` dict when
-        the call must be rejected (else ``None``); ``price`` is the validated
-        per-call price when a guard applies (else ``None``).
+        Returns ``(denial, price, described)``: ``denial`` is a ``{"error": ...}``
+        dict when the call must be rejected (else ``None``); ``price`` is the
+        validated per-call price when a guard applies (else ``None``);
+        ``described`` is the describe response fetched for the guard (else
+        ``None``) so the caller can reuse it (e.g. to derive the HTTP method)
+        without a second network round-trip.
         """
         if self.max_cost_per_call is None and self.max_session_spend is None:
-            return None, None
+            return None, None, None
         described = self.describe(tool_id)
         if isinstance(described, dict) and "error" in described:
-            return described, None
+            return described, None, None
         # Accept the same price field names tolerated by spend recording so the
         # budget check does not fail closed on a field-name mismatch against the
         # live registry schema (``price_per_call`` -> ``price`` -> ``cost``).
@@ -226,14 +259,14 @@ class RegistryProxyTool(BaseTool):
                     "Denied: price (price_per_call/price/cost) is missing or "
                     "invalid, cannot enforce the configured spend guard."
                 )
-            }, None
+            }, None, described
         if self.max_cost_per_call is not None and price > self.max_cost_per_call:
             return {
                 "error": (
                     f"Denied: price per call {price} exceeds max_cost_per_call "
                     f"{self.max_cost_per_call}."
                 )
-            }, price
+            }, price, described
         if (
             self.max_session_spend is not None
             and self._session_spend + price > self.max_session_spend
@@ -244,30 +277,56 @@ class RegistryProxyTool(BaseTool):
                     f"{self._session_spend + price}, exceeding max_session_spend "
                     f"{self.max_session_spend}."
                 )
-            }, price
-        return None, price
+            }, price, described
+        return None, price, described
 
-    def call(self, tool_id: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Invoke an endpoint through the proxy (credential injected server-side)."""
+    def call(
+        self,
+        tool_id: str,
+        params: Optional[Dict[str, Any]] = None,
+        method: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Invoke an endpoint through the proxy (credential injected server-side).
+
+        The registry enforces each endpoint's declared HTTP method on
+        ``/call/{id}``. When ``method`` is not supplied it is derived from
+        ``describe`` (the endpoint doc carries ``method``); GET requests send
+        ``params`` as the query string, POST/PUT (and others) send them as a
+        JSON body.
+        """
         missing = self._require_config()
         if missing:
             return missing
         if not tool_id:
             return {"error": "tool_id is required"}
-        denied, quoted_price = self._check_budget(tool_id)
+        denied, quoted_price, described = self._check_budget(tool_id)
         if denied:
             return denied
+        # Derive the HTTP method from the endpoint doc when not supplied. Reuse
+        # the describe fetched by the spend guard when present to avoid a second
+        # round-trip; otherwise fetch describe only when the method is unknown.
+        if method is None:
+            if described is None:
+                described = self.describe(tool_id)
+                if isinstance(described, dict) and "error" in described:
+                    return described
+            method = self._extract_method(described)
+        method = (method or "POST").upper()
         try:
             import httpx
         except ImportError:
             return {"error": _INSTALL_HINT}
+        url = f"{self.proxy_url}/call/{tool_id}"
         try:
             with httpx.Client(timeout=self.timeout) as client:
-                response = client.post(
-                    f"{self.proxy_url}/call/{tool_id}",
-                    json=params or {},
-                    headers=self._headers(),
-                )
+                if method == "GET":
+                    response = client.get(
+                        url, params=params or {}, headers=self._headers()
+                    )
+                else:
+                    response = client.request(
+                        method, url, json=params or {}, headers=self._headers()
+                    )
                 response.raise_for_status()
                 result = response.json()
         except httpx.TimeoutException:
@@ -323,6 +382,7 @@ def registry_describe(
     proxy_url: Optional[str] = None,
     token: Optional[str] = None,
     auth_header: Optional[str] = None,
+    describe_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Describe one registry catalogue entry.
 
@@ -335,12 +395,16 @@ def registry_describe(
         token: Proxy token (defaults to TOOL_PROXY_TOKEN env var).
         auth_header: Auth header name (defaults to TOOL_PROXY_AUTH_HEADER env var,
             then ``Authorization``).
+        describe_path: Path template for the describe route (defaults to
+            TOOL_PROXY_DESCRIBE_PATH env var, then ``/catalog/endpoints/{tool_id}``).
+            Must contain ``{tool_id}``.
 
     Returns:
         Dict describing the entry, or ``{"error": ...}`` on failure.
     """
     return RegistryProxyTool(
-        proxy_url=proxy_url, token=token, auth_header=auth_header
+        proxy_url=proxy_url, token=token, auth_header=auth_header,
+        describe_path=describe_path,
     ).describe(tool_id)
 
 
@@ -353,12 +417,23 @@ def registry_call(
     max_cost_per_call: Optional[float] = None,
     max_session_spend: Optional[float] = None,
     auth_header: Optional[str] = None,
+    method: Optional[str] = None,
+    describe_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Invoke a registry endpoint through the proxy.
 
     Paid call. The registry injects the upstream vendor credential server-side,
     so no vendor keys are ever held by the agent. Optional spend guards deny +
     report the call when a configured budget would be exceeded.
+
+    The registry enforces each endpoint's declared HTTP method. When ``method``
+    is not supplied it is derived from ``registry_describe`` (the endpoint doc
+    carries ``method``); GET params are sent as the query string, POST/PUT as a
+    JSON body.
+
+    Note: passthrough-URL calls require the upstream to be registered on the
+    registry first; loopback/private upstreams are refused by the registry's
+    SSRF guard by design.
 
     Args:
         tool_id: Catalogue entry identifier (from ``registry_search``).
@@ -370,6 +445,10 @@ def registry_call(
         auth_header: Auth header name (defaults to TOOL_PROXY_AUTH_HEADER env var,
             then ``Authorization``). ``Authorization`` sends ``Bearer {token}``;
             any other name (e.g. ``X-Treg-Token``) sends the raw token.
+        method: HTTP method for the endpoint (e.g. ``GET``/``POST``). When
+            omitted it is derived from the endpoint's describe doc.
+        describe_path: Path template for the describe route (defaults to
+            TOOL_PROXY_DESCRIBE_PATH env var, then ``/catalog/endpoints/{tool_id}``).
 
     Returns:
         Dict with the endpoint response, or ``{"error": ...}`` on failure/denial.
@@ -380,4 +459,5 @@ def registry_call(
         max_cost_per_call=max_cost_per_call,
         max_session_spend=max_session_spend,
         auth_header=auth_header,
-    ).call(tool_id, params)
+        describe_path=describe_path,
+    ).call(tool_id, params, method)

--- a/praisonai_tools/registry_proxy/registry_proxy.py
+++ b/praisonai_tools/registry_proxy/registry_proxy.py
@@ -21,6 +21,7 @@ Design notes:
 import os
 import logging
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 from praisonai_tools.tools.base import BaseTool
 from praisonai_tools.tools.decorator import tool
@@ -33,6 +34,11 @@ _INSTALL_HINT = "httpx not installed. Install with: pip install 'praisonai-tools
 # persists across the short-lived connector instances created by the decorated
 # functions, without mixing budgets across distinct accounts/endpoints.
 _SESSION_SPEND: Dict[tuple, float] = {}
+
+# The registry enforces the endpoint's declared HTTP method on ``/call/{id}``.
+# Restricting to a known set keeps the wire behaviour predictable and returns a
+# clear tool-result error instead of forwarding a mislabelled/unexpected verb.
+_ALLOWED_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE"})
 
 
 class RegistryProxyTool(BaseTool):
@@ -183,7 +189,21 @@ class RegistryProxyTool(BaseTool):
             import httpx
         except ImportError:
             return {"error": _INSTALL_HINT}
-        path = self.describe_path.format(tool_id=tool_id)
+        if "{tool_id}" not in self.describe_path:
+            return {
+                "error": (
+                    f"Invalid describe path template '{self.describe_path}': "
+                    "it must contain '{tool_id}'."
+                )
+            }
+        try:
+            path = self.describe_path.format(tool_id=quote(tool_id, safe=""))
+        except (KeyError, IndexError, ValueError) as exc:
+            return {
+                "error": (
+                    f"Invalid describe path template '{self.describe_path}': {exc}"
+                )
+            }
         if not path.startswith("/"):
             path = "/" + path
         try:
@@ -311,12 +331,19 @@ class RegistryProxyTool(BaseTool):
                 if isinstance(described, dict) and "error" in described:
                     return described
             method = self._extract_method(described)
-        method = (method or "POST").upper()
+        method = (method or "POST").strip().upper()
+        if method not in _ALLOWED_METHODS:
+            return {
+                "error": (
+                    f"Unsupported HTTP method '{method}'. Allowed: "
+                    f"{', '.join(sorted(_ALLOWED_METHODS))}."
+                )
+            }
         try:
             import httpx
         except ImportError:
             return {"error": _INSTALL_HINT}
-        url = f"{self.proxy_url}/call/{tool_id}"
+        url = f"{self.proxy_url}/call/{quote(tool_id, safe='')}"
         try:
             with httpx.Client(timeout=self.timeout) as client:
                 if method == "GET":

--- a/tests/test_registry_proxy.py
+++ b/tests/test_registry_proxy.py
@@ -158,37 +158,228 @@ class TestDescribe:
 
         assert result["price_per_call"] == 0.01
         client.get.assert_called_once_with(
+            "https://r.example.com/catalog/endpoints/seo.backlinks",
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_describe_uses_endpoints_path(self, mock_httpx):
+        """The real registry route is /catalog/endpoints/{id}, not /catalog/{id}."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        response = Mock()
+        response.json.return_value = {"id": "diffbot.people.enrich", "method": "GET"}
+        response.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = response
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", token="t")
+        tool.describe("diffbot.people.enrich")
+
+        client.get.assert_called_once_with(
+            "https://r.example.com/catalog/endpoints/diffbot.people.enrich",
+            headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+        )
+
+    def test_describe_path_configurable(self, mock_httpx):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        response = Mock()
+        response.json.return_value = {"id": "seo.backlinks"}
+        response.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = response
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(
+            proxy_url="https://r.example.com",
+            describe_path="/catalog/{tool_id}",
+        )
+        tool.describe("seo.backlinks")
+
+        client.get.assert_called_once_with(
             "https://r.example.com/catalog/seo.backlinks",
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_describe_path_from_env(self, mock_httpx):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        response = Mock()
+        response.json.return_value = {"id": "seo.backlinks"}
+        response.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = response
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        with patch.dict(os.environ, {
+            "TOOL_PROXY_URL": "https://r.example.com",
+            "TOOL_PROXY_DESCRIBE_PATH": "/v2/endpoints/{tool_id}",
+        }):
+            tool = RegistryProxyTool()
+            tool.describe("seo.backlinks")
+
+        client.get.assert_called_once_with(
+            "https://r.example.com/v2/endpoints/seo.backlinks",
             headers={"Content-Type": "application/json"},
         )
 
 
 class TestCall:
     def test_call_success(self, mock_httpx):
+        """Explicit method=POST skips describe and posts a JSON body."""
         from praisonai_tools.registry_proxy import RegistryProxyTool
 
         response = Mock()
         response.json.return_value = {"data": {"backlinks": 42}}
         response.raise_for_status.return_value = None
         client = Mock()
-        client.post.return_value = response
+        client.request.return_value = response
         mock_httpx.Client.return_value.__enter__.return_value = client
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com", token="t")
-        result = tool.call("seo.backlinks", {"domain": "example.com"})
+        result = tool.call("seo.backlinks", {"domain": "example.com"}, method="POST")
 
         assert result["data"]["backlinks"] == 42
-        client.post.assert_called_once_with(
+        client.request.assert_called_once_with(
+            "POST",
             "https://r.example.com/call/seo.backlinks",
             json={"domain": "example.com"},
             headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
         )
+        client.get.assert_not_called()
 
     def test_call_requires_tool_id(self):
         from praisonai_tools.registry_proxy import RegistryProxyTool
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com")
         assert tool.call("")["error"] == "tool_id is required"
+
+    def test_call_derives_post_method_from_describe(self, mock_httpx):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {"id": "seo.backlinks", "method": "POST"}
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": {"backlinks": 42}}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = describe_resp
+        client.request.return_value = call_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", token="t")
+        result = tool.call("seo.backlinks", {"domain": "example.com"})
+
+        assert result["data"]["backlinks"] == 42
+        client.request.assert_called_once_with(
+            "POST",
+            "https://r.example.com/call/seo.backlinks",
+            json={"domain": "example.com"},
+            headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+        )
+
+    def test_call_uses_declared_method(self, mock_httpx):
+        """describe says GET -> GET with query params (no JSON body)."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {
+            "id": "diffbot.people.enrich", "method": "GET"
+        }
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": {"name": "Jane"}}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.side_effect = [describe_resp, call_resp]
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", token="t")
+        result = tool.call("diffbot.people.enrich", {"query": "type=email"})
+
+        assert result["data"]["name"] == "Jane"
+        client.request.assert_not_called()
+        # First get = describe, second get = the GET call with query params.
+        assert client.get.call_count == 2
+        call_args = client.get.call_args_list[1]
+        assert call_args.args[0] == "https://r.example.com/call/diffbot.people.enrich"
+        assert call_args.kwargs["params"] == {"query": "type=email"}
+
+    def test_call_explicit_get_skips_describe(self, mock_httpx):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": "ok"}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = call_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", token="t")
+        result = tool.call("diffbot.people.enrich", {"q": "x"}, method="GET")
+
+        assert result["data"] == "ok"
+        client.get.assert_called_once_with(
+            "https://r.example.com/call/diffbot.people.enrich",
+            params={"q": "x"},
+            headers={"Content-Type": "application/json", "Authorization": "Bearer t"},
+        )
+
+    def test_call_defaults_to_post_when_method_absent(self, mock_httpx):
+        """describe omits method -> default to POST with JSON body."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {"id": "seo.backlinks"}
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": "ok"}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = describe_resp
+        client.request.return_value = call_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com")
+        result = tool.call("seo.backlinks", {"domain": "x"})
+
+        assert result["data"] == "ok"
+        client.request.assert_called_once_with(
+            "POST",
+            "https://r.example.com/call/seo.backlinks",
+            json={"domain": "x"},
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_guarded_call_works_on_get_endpoint(self, mock_httpx):
+        """Regression: spend guard + GET endpoint end-to-end (describe fetched once)."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {
+            "id": "diffbot.people.enrich", "method": "GET", "price_per_call": 0.05
+        }
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": "ok", "price_per_call": 0.05}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.side_effect = [describe_resp, call_resp]
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(
+            proxy_url="https://r.example.com", max_session_spend=1.0
+        )
+        result = tool.call("diffbot.people.enrich", {"query": "type=email"})
+
+        assert result["data"] == "ok"
+        assert tool._session_spend == pytest.approx(0.05)
+        client.request.assert_not_called()
+        # describe reused from the guard: exactly one describe + one GET call.
+        assert client.get.call_count == 2
+        assert client.get.call_args_list[1].kwargs["params"] == {"query": "type=email"}
 
 
 class TestErrorTaxonomy:
@@ -213,11 +404,11 @@ class TestErrorTaxonomy:
         resp.status_code = 402
         resp.text = "Payment Required"
         client = Mock()
-        client.post.side_effect = mock_httpx.HTTPStatusError("402", response=resp)
+        client.request.side_effect = mock_httpx.HTTPStatusError("402", response=resp)
         mock_httpx.Client.return_value.__enter__.return_value = client
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com")
-        result = tool.call("seo.backlinks", {})
+        result = tool.call("seo.backlinks", {}, method="POST")
         assert "Insufficient balance" in result["error"]
 
     def test_upstream_4xx_passthrough(self, mock_httpx):
@@ -227,11 +418,11 @@ class TestErrorTaxonomy:
         resp.status_code = 404
         resp.text = "Not Found"
         client = Mock()
-        client.post.side_effect = mock_httpx.HTTPStatusError("404", response=resp)
+        client.request.side_effect = mock_httpx.HTTPStatusError("404", response=resp)
         mock_httpx.Client.return_value.__enter__.return_value = client
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com")
-        result = tool.call("seo.backlinks", {})
+        result = tool.call("seo.backlinks", {}, method="POST")
         assert "HTTP 404" in result["error"]
 
     def test_timeout_error(self, mock_httpx):
@@ -299,7 +490,7 @@ class TestSpendGuards:
         call_resp.raise_for_status.return_value = None
         client = Mock()
         client.get.return_value = describe_resp
-        client.post.return_value = call_resp
+        client.request.return_value = call_resp
         mock_httpx.Client.return_value.__enter__.return_value = client
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com", max_session_spend=1.0)
@@ -320,7 +511,7 @@ class TestSpendGuards:
         call_resp.raise_for_status.return_value = None
         client = Mock()
         client.get.return_value = describe_resp
-        client.post.return_value = call_resp
+        client.request.return_value = call_resp
         mock_httpx.Client.return_value.__enter__.return_value = client
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com", max_session_spend=1.0)
@@ -355,7 +546,7 @@ class TestSpendGuards:
         call_resp.raise_for_status.return_value = None
         client = Mock()
         client.get.return_value = describe_resp
-        client.post.return_value = call_resp
+        client.request.return_value = call_resp
         mock_httpx.Client.return_value.__enter__.return_value = client
 
         first = registry_call(
@@ -410,8 +601,28 @@ class TestDecoratedFunctions:
             max_cost_per_call=0.1,
             max_session_spend=1.0,
             auth_header=None,
+            describe_path=None,
         )
-        instance.call.assert_called_once_with("seo.backlinks", {"domain": "x"})
+        instance.call.assert_called_once_with("seo.backlinks", {"domain": "x"}, None)
+
+    @patch("praisonai_tools.registry_proxy.registry_proxy.RegistryProxyTool")
+    def test_registry_call_function_passes_method(self, mock_cls):
+        from praisonai_tools.registry_proxy import registry_call
+
+        instance = Mock()
+        instance.call.return_value = {"data": "ok"}
+        mock_cls.return_value = instance
+
+        registry_call(
+            "diffbot.people.enrich",
+            {"query": "type=email"},
+            proxy_url="https://r",
+            token="t",
+            method="GET",
+        )
+        instance.call.assert_called_once_with(
+            "diffbot.people.enrich", {"query": "type=email"}, "GET"
+        )
 
 
 def test_smoke_import():

--- a/tests/test_registry_proxy.py
+++ b/tests/test_registry_proxy.py
@@ -224,6 +224,57 @@ class TestDescribe:
             headers={"Content-Type": "application/json"},
         )
 
+    def test_describe_path_missing_placeholder_errors(self, mock_httpx):
+        """A template lacking {tool_id} must return an error, not silently misroute."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        client = Mock()
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(
+            proxy_url="https://r.example.com",
+            describe_path="/catalog/static",
+        )
+        result = tool.describe("seo.backlinks")
+
+        assert "must contain '{tool_id}'" in result["error"]
+        client.get.assert_not_called()
+
+    def test_describe_path_malformed_template_errors(self, mock_httpx):
+        """A malformed template must return an error instead of raising."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        client = Mock()
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(
+            proxy_url="https://r.example.com",
+            describe_path="/catalog/{tool_id}/{unknown}",
+        )
+        result = tool.describe("seo.backlinks")
+
+        assert "Invalid describe path template" in result["error"]
+        client.get.assert_not_called()
+
+    def test_describe_encodes_tool_id(self, mock_httpx):
+        """A tool_id with path-changing characters is URL-encoded."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        response = Mock()
+        response.json.return_value = {"id": "x"}
+        response.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = response
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com")
+        tool.describe("../admin?x=1")
+
+        client.get.assert_called_once_with(
+            "https://r.example.com/catalog/endpoints/..%2Fadmin%3Fx%3D1",
+            headers={"Content-Type": "application/json"},
+        )
+
 
 class TestCall:
     def test_call_success(self, mock_httpx):
@@ -254,6 +305,63 @@ class TestCall:
 
         tool = RegistryProxyTool(proxy_url="https://r.example.com")
         assert tool.call("")["error"] == "tool_id is required"
+
+    def test_call_normalizes_explicit_method_whitespace(self, mock_httpx):
+        """An explicit method with whitespace/casing is normalized (GET -> query)."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        response = Mock()
+        response.json.return_value = {"data": {"ok": True}}
+        response.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = response
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com")
+        result = tool.call("t.id", {"q": "x"}, method=" get ")
+
+        assert result["data"]["ok"] is True
+        client.get.assert_called_once_with(
+            "https://r.example.com/call/t.id",
+            params={"q": "x"},
+            headers={"Content-Type": "application/json"},
+        )
+        client.request.assert_not_called()
+
+    def test_call_rejects_unsupported_method(self, mock_httpx):
+        """An unsupported/mislabelled method is rejected before any request."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        client = Mock()
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com")
+        result = tool.call("t.id", {}, method="TRACE")
+
+        assert "Unsupported HTTP method 'TRACE'" in result["error"]
+        client.get.assert_not_called()
+        client.request.assert_not_called()
+
+    def test_call_encodes_tool_id_in_url(self, mock_httpx):
+        """A tool_id with path-changing characters is URL-encoded on /call."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        response = Mock()
+        response.json.return_value = {"data": "ok"}
+        response.raise_for_status.return_value = None
+        client = Mock()
+        client.request.return_value = response
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com")
+        tool.call("../admin", {}, method="POST")
+
+        client.request.assert_called_once_with(
+            "POST",
+            "https://r.example.com/call/..%2Fadmin",
+            json={},
+            headers={"Content-Type": "application/json"},
+        )
 
     def test_call_derives_post_method_from_describe(self, mock_httpx):
         from praisonai_tools.registry_proxy import RegistryProxyTool
@@ -461,7 +569,7 @@ class TestSpendGuards:
         tool = RegistryProxyTool(proxy_url="https://r.example.com", max_cost_per_call=0.10)
         result = tool.call("seo.backlinks", {})
         assert "exceeds max_cost_per_call" in result["error"]
-        client.post.assert_not_called()
+        client.request.assert_not_called()
 
     def test_max_session_spend_denies(self, mock_httpx):
         from praisonai_tools.registry_proxy import RegistryProxyTool
@@ -477,7 +585,7 @@ class TestSpendGuards:
         tool._session_spend = 0.50
         result = tool.call("seo.backlinks", {})
         assert "max_session_spend" in result["error"]
-        client.post.assert_not_called()
+        client.request.assert_not_called()
 
     def test_within_budget_allows_and_tracks_spend(self, mock_httpx):
         from praisonai_tools.registry_proxy import RegistryProxyTool
@@ -532,7 +640,7 @@ class TestSpendGuards:
         tool = RegistryProxyTool(proxy_url="https://r.example.com", max_cost_per_call=0.10)
         result = tool.call("seo.backlinks", {})
         assert "cannot enforce" in result["error"]
-        client.post.assert_not_called()
+        client.request.assert_not_called()
 
     def test_session_spend_persists_across_registry_call(self, mock_httpx):
         """max_session_spend must accumulate across separate registry_call calls."""


### PR DESCRIPTION
Fixes #83

## Summary
Addresses the two wire gaps surfaced by the live verification against a self-hosted registry (v0.11.0):

1. **Describe path** — `describe` now hits `/catalog/endpoints/{tool_id}` (the real route) instead of `/catalog/{tool_id}`. The path template is configurable via `TOOL_PROXY_DESCRIBE_PATH` (or the `describe_path` arg) for other registry layouts. This also un-breaks spend-guarded calls, which failed closed on every catalogue tool because describe 404'd.

2. **HTTP method support** — `registry_call` now honours the endpoint's declared HTTP method (the registry enforces it on `/call/{id}`). When `method` is not supplied it is **derived from describe** — reusing the describe fetched by the spend guard when present, so no extra round-trip. `GET` sends `params` as the query string; `POST`/`PUT` (and others) send a JSON body. `method` can be passed explicitly to skip the lookup.

3. **Docs** — added `TOOL_PROXY_DESCRIBE_PATH`, an HTTP-methods section, and a passthrough-URL / SSRF note (loopback/private upstreams are refused by the registry by design).

## Tests
Added/updated unit tests, all passing (`37 passed, 1 skipped`):
- `test_describe_uses_endpoints_path`, `test_describe_path_configurable`, `test_describe_path_from_env`
- `test_call_uses_declared_method` (GET → query params), `test_call_derives_post_method_from_describe`, `test_call_explicit_get_skips_describe`, `test_call_defaults_to_post_when_method_absent`
- `test_guarded_call_works_on_get_endpoint` (regression: guard + GET end-to-end, describe reused)
- Refreshed error-taxonomy and spend-guard mocks to the new call path.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable paths for retrieving tool descriptions.
  - Tool calls now support automatic HTTP-method selection based on endpoint metadata.
  - Added support for GET query parameters and JSON request bodies for other HTTP methods.
  - Added optional explicit HTTP method selection for tool calls.

- **Documentation**
  - Documented description-path configuration, HTTP-method handling, and passthrough URL requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->