### PR TITLE
fix: unwrap describe envelope and structured cost in registry_proxy

### DIFF
--- a/praisonai_tools/registry_proxy/registry_proxy.py
+++ b/praisonai_tools/registry_proxy/registry_proxy.py
@@ -19,6 +19,7 @@ Design notes:
 """
 
 import os
+import math
 import logging
 from typing import Any, Dict, Optional
 from urllib.parse import quote
@@ -306,6 +307,16 @@ class RegistryProxyTool(BaseTool):
                     "invalid, cannot enforce the configured spend guard."
                 )
             }, None, described
+        # Fail closed on non-finite (NaN/inf) or negative prices: NaN comparisons
+        # are always false, so an unvalidated NaN would silently bypass both the
+        # per-call and session guards and then corrupt ``_session_spend``.
+        if not math.isfinite(price) or price < 0:
+            return {
+                "error": (
+                    "Denied: price (price_per_call/price/cost) is missing or "
+                    "invalid, cannot enforce the configured spend guard."
+                )
+            }, None, described
         if self.max_cost_per_call is not None and price > self.max_cost_per_call:
             return {
                 "error": (
@@ -395,10 +406,16 @@ class RegistryProxyTool(BaseTool):
         # still accrues when the response omits cost fields.
         charged = self._extract_price(result)
         try:
-            self._session_spend += float(charged)
+            charged = float(charged)
+            if not math.isfinite(charged) or charged < 0:
+                raise ValueError("non-finite or negative charge")
         except (TypeError, ValueError):
-            if quoted_price is not None:
-                self._session_spend += quoted_price
+            # The response omitted a usable charge; fall back to the finite,
+            # non-negative price validated at budget-check time so a malformed
+            # (NaN/inf/negative) response cannot corrupt cumulative spend.
+            charged = quoted_price
+        if charged is not None:
+            self._session_spend += charged
         return result
 
 

--- a/praisonai_tools/registry_proxy/registry_proxy.py
+++ b/praisonai_tools/registry_proxy/registry_proxy.py
@@ -223,12 +223,30 @@ class RegistryProxyTool(BaseTool):
             return {"error": str(exc)}
 
     @staticmethod
-    def _extract_method(data: Any) -> Optional[str]:
+    def _unwrap_envelope(data: Any) -> Any:
+        """Return the dict that carries the endpoint fields.
+
+        The live registry nests ``method``/``cost`` under an ``endpoint`` key
+        (``{"endpoint": {...}, "provider": {}, ...}``); flatter registry
+        implementations put them at the top level. Prefer ``data["endpoint"]``
+        when it is a dict, else use ``data`` itself.
+        """
+        if not isinstance(data, dict):
+            return data
+        endpoint = data.get("endpoint")
+        if isinstance(endpoint, dict):
+            return endpoint
+        return data
+
+    @classmethod
+    def _extract_method(cls, data: Any) -> Optional[str]:
         """Read the HTTP method from a describe response, if present.
 
-        The live registry's endpoint doc carries ``method: "GET"`` (or POST/PUT);
-        the registry enforces the declared method on ``/call/{id}``.
+        The live registry's endpoint doc carries ``method: "GET"`` (or POST/PUT)
+        nested under ``endpoint``; the registry enforces the declared method on
+        ``/call/{id}``. Flat implementations expose it at the top level.
         """
+        data = cls._unwrap_envelope(data)
         if not isinstance(data, dict):
             return None
         method = data.get("method")
@@ -236,18 +254,26 @@ class RegistryProxyTool(BaseTool):
             return method.strip().upper()
         return None
 
-    @staticmethod
-    def _extract_price(data: Any) -> Any:
-        """Read a price from a response, tolerating field-name variation.
+    @classmethod
+    def _extract_price(cls, data: Any) -> Any:
+        """Read a price from a response, tolerating field-name/shape variation.
 
-        Tries ``price_per_call`` then ``price`` then ``cost`` so the budget check
-        and spend recording share the same tolerance against the live schema.
+        Unwraps the ``endpoint`` envelope, then tries ``price_per_call`` then
+        ``price`` then ``cost`` so the budget check and spend recording share the
+        same tolerance against the live schema. ``cost`` may be a structured
+        object (``{"value": 25, "currency": "credit", "usd": 0.0299, ...}``); in
+        that case prefer ``usd`` since the guard budgets are in USD (``value`` is
+        in provider credits). Flat numeric forms are returned unchanged.
         """
+        data = cls._unwrap_envelope(data)
         if not isinstance(data, dict):
             return None
         for key in ("price_per_call", "price", "cost"):
             if key in data:
-                return data[key]
+                value = data[key]
+                if isinstance(value, dict):
+                    return value.get("usd")
+                return value
         return None
 
     def _check_budget(self, tool_id: str):

--- a/tests/test_registry_proxy.py
+++ b/tests/test_registry_proxy.py
@@ -746,6 +746,43 @@ class TestSpendGuards:
         assert "cannot enforce" in result["error"]
         client.request.assert_not_called()
 
+    @pytest.mark.parametrize("bad_price", ["NaN", "Infinity", "-Infinity", -0.01])
+    def test_non_finite_or_negative_price_fails_closed(self, mock_httpx, bad_price):
+        """NaN/inf/negative prices must be rejected, not silently bypass the guard."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {"price_per_call": bad_price}
+        describe_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = describe_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", max_cost_per_call=0.10)
+        result = tool.call("seo.backlinks", {})
+        assert "cannot enforce" in result["error"]
+        client.request.assert_not_called()
+
+    def test_non_finite_response_charge_does_not_corrupt_spend(self, mock_httpx):
+        """A NaN/inf charge in the call response must not poison cumulative spend."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = {"price_per_call": 0.20}
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": "ok", "price_per_call": "NaN"}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = describe_resp
+        client.request.return_value = call_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", max_session_spend=1.0)
+        result = tool.call("seo.backlinks", {})
+        assert result["data"] == "ok"
+        assert tool._session_spend == 0.20
+
     def test_session_spend_persists_across_registry_call(self, mock_httpx):
         """max_session_spend must accumulate across separate registry_call calls."""
         from praisonai_tools.registry_proxy import registry_call

--- a/tests/test_registry_proxy.py
+++ b/tests/test_registry_proxy.py
@@ -490,6 +490,110 @@ class TestCall:
         assert client.get.call_args_list[1].kwargs["params"] == {"query": "type=email"}
 
 
+# The live registry (v0.11.0) nests the endpoint fields under an ``endpoint``
+# key and expresses cost as a structured object; fixtures mirror that shape so
+# unit tests exercise the real wire schema, not a flattened approximation.
+_LIVE_ENDPOINT_DOC = {
+    "endpoint": {
+        "id": "diffbot.people.enrich",
+        "method": "GET",
+        "cost": {
+            "type": "per_call",
+            "value": 25,
+            "currency": "credit",
+            "per": 1,
+            "usd": 0.0299,
+        },
+    },
+    "provider": {},
+    "siblings": [],
+    "call_template": "…",
+    "example_response": {},
+    "hints": [],
+}
+
+
+class TestExtractors:
+    def test_extract_method_nested_endpoint_envelope(self):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        assert RegistryProxyTool._extract_method(
+            {"endpoint": {"method": "GET"}}
+        ) == "GET"
+        # Flat form still works.
+        assert RegistryProxyTool._extract_method({"method": "post"}) == "POST"
+        # Absent -> None (default POST applies downstream).
+        assert RegistryProxyTool._extract_method({"endpoint": {}}) is None
+        assert RegistryProxyTool._extract_method({}) is None
+
+    def test_extract_price_structured_cost_usd(self):
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        # Nested endpoint.cost.usd is preferred (guard budgets are USD).
+        assert RegistryProxyTool._extract_price(_LIVE_ENDPOINT_DOC) == 0.0299
+        assert RegistryProxyTool._extract_price(
+            {"cost": {"usd": 0.0299, "value": 25}}
+        ) == 0.0299
+        # Flat numeric forms unchanged.
+        assert RegistryProxyTool._extract_price({"price_per_call": 0.05}) == 0.05
+        assert RegistryProxyTool._extract_price({"price": 0.02}) == 0.02
+        assert RegistryProxyTool._extract_price({"cost": 0.03}) == 0.03
+        # Nested flat number under the envelope.
+        assert RegistryProxyTool._extract_price(
+            {"endpoint": {"price_per_call": 0.07}}
+        ) == 0.07
+        # Non-numeric/absent -> None (fail-closed downstream).
+        assert RegistryProxyTool._extract_price({"cost": {"value": 25}}) is None
+        assert RegistryProxyTool._extract_price({}) is None
+
+
+class TestLiveEnvelope:
+    def test_call_auto_derives_get_from_live_shape(self, mock_httpx):
+        """The live nested envelope must yield an auto-derived GET (no method=)."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = _LIVE_ENDPOINT_DOC
+        describe_resp.raise_for_status.return_value = None
+        call_resp = Mock()
+        call_resp.json.return_value = {"data": {"name": "Jane"}}
+        call_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.side_effect = [describe_resp, call_resp]
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(proxy_url="https://r.example.com", token="t")
+        result = tool.call("diffbot.people.enrich", {"query": "type=email"})
+
+        assert result["data"]["name"] == "Jane"
+        client.request.assert_not_called()
+        assert client.get.call_count == 2
+        call_args = client.get.call_args_list[1]
+        assert call_args.args[0] == "https://r.example.com/call/diffbot.people.enrich"
+        assert call_args.kwargs["params"] == {"query": "type=email"}
+
+    def test_guard_quotes_real_price_from_live_shape(self, mock_httpx):
+        """Guard must quote the structured cost's usd, not fail-closed."""
+        from praisonai_tools.registry_proxy import RegistryProxyTool
+
+        describe_resp = Mock()
+        describe_resp.json.return_value = _LIVE_ENDPOINT_DOC
+        describe_resp.raise_for_status.return_value = None
+        client = Mock()
+        client.get.return_value = describe_resp
+        mock_httpx.Client.return_value.__enter__.return_value = client
+
+        tool = RegistryProxyTool(
+            proxy_url="https://r.example.com", max_cost_per_call=0.01
+        )
+        result = tool.call("diffbot.people.enrich", {"query": "type=email"})
+
+        assert "exceeds max_cost_per_call" in result["error"]
+        assert "0.0299" in result["error"]
+        assert "cannot enforce" not in result["error"]
+        client.request.assert_not_called()
+
+
 class TestErrorTaxonomy:
     def test_auth_error(self, mock_httpx):
         from praisonai_tools.registry_proxy import RegistryProxyTool


### PR DESCRIPTION
Fixes #85

## Summary
- `_extract_method` and `_extract_price` now unwrap the live registry's `endpoint` envelope before reading fields (via a shared `_unwrap_envelope` helper), so `{"endpoint": {"method": "GET"}}` correctly derives GET.
- `_extract_price` handles the structured `cost` object by preferring `usd` (guard budgets are USD; `value` is provider credits). Flat numeric forms (`price_per_call`/`price`/`cost`) are unchanged, and fail-closed is preserved when nothing parses.
- Spend recording shares the same `_extract_price`, so live-shaped call responses are handled identically.
- Fixtures now mirror the verified live envelope (nested `endpoint` + structured `cost`).

## Tests
- `test_extract_method_nested_endpoint_envelope`
- `test_extract_price_structured_cost_usd`
- `test_call_auto_derives_get_from_live_shape`
- `test_guard_quotes_real_price_from_live_shape`

`pytest tests/test_registry_proxy.py`: 47 passed, 1 skipped.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with registry responses that wrap endpoint details in nested objects.
  * Correctly reads structured USD pricing information for budget checks and spend tracking.
  * Preserved support for existing flat response formats.
  * Maintained automatic GET request handling and budget enforcement with current response formats.

* **Tests**
  * Added coverage for nested endpoint data, structured pricing, request dispatch, and budget limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->