### PR TITLE
fix: stop swallowing docs.json nav update failures

### DIFF
--- a/praisonai_tools/docs_generator/generator.py
+++ b/praisonai_tools/docs_generator/generator.py
@@ -3327,9 +3327,11 @@ class ReferenceDocsGenerator:
             
             with open(self.docs_json_path, 'w') as f:
                 json.dump(docs_config, f, indent=2)
-                
-        except Exception:
-            pass
+            print(f"  Updated docs.json: {len(unique_pages)} pages for {package_name}")
+
+        except Exception as exc:
+            print(f"  Error updating docs.json for {package_name}: {exc}")
+            raise
 
 if __name__ == "__main__":
     import argparse

--- a/praisonai_tools/docs_generator/generator.py
+++ b/praisonai_tools/docs_generator/generator.py
@@ -3327,7 +3327,12 @@ class ReferenceDocsGenerator:
             
             with open(self.docs_json_path, 'w') as f:
                 json.dump(docs_config, f, indent=2)
-            print(f"  Updated docs.json: {len(unique_pages)} pages for {package_name}")
+
+            if self.layout == LayoutType.GRANULAR:
+                page_count = sum(len(group.get('pages', [])) for group in package_group['pages'])
+            else:
+                page_count = len(package_group['pages'])
+            print(f"  Updated docs.json: {page_count} pages for {package_name}")
 
         except Exception as exc:
             print(f"  Error updating docs.json for {package_name}: {exc}")


### PR DESCRIPTION
## Summary
- `ReferenceDocsGenerator.update_docs_json()` previously used bare `except Exception: pass`, so failed nav updates were silent.
- This caused PraisonAIDocs auto-generate pushes to add SDK reference MDX without syncing `docs.json`, failing `nav-check` on all docs PRs.

## Test plan
- [x] Verified nav fix in PraisonAIDocs PR #3054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation updates now report failures clearly instead of silently suppressing them.
  * Successful documentation updates provide confirmation messages.
  * Error messages include the affected package context for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->