### PR TITLE
fix: update docs/docs.json path for Mintlify subpath hosting

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -77,6 +77,9 @@ jobs:
             --package all \
             --docs-root $(pwd)/praisonai-docs \
             --source-root $(pwd)/praisonai-source
+
+      - name: Sync SDK reference navigation
+        run: python3 praisonai-docs/scripts/sync_sdk_reference_nav.py
         env:
           PYTHONPATH: $(pwd)/praisonai-tools
 

--- a/praisonai_tools/docs_generator/generator.py
+++ b/praisonai_tools/docs_generator/generator.py
@@ -3125,7 +3125,15 @@ class ReferenceDocsGenerator:
         layout: LayoutType = LayoutType.GRANULAR
     ):
         self.docs_root = Path(docs_root)
-        self.docs_json_path = self.docs_root / "docs.json"
+        # Mintlify subpath hosting uses docs/docs.json (see PraisonAIDocs migrate script).
+        docs_json_in_docs = self.docs_root / "docs" / "docs.json"
+        docs_json_at_root = self.docs_root / "docs.json"
+        if docs_json_in_docs.exists():
+            self.docs_json_path = docs_json_in_docs
+        elif docs_json_at_root.exists():
+            self.docs_json_path = docs_json_at_root
+        else:
+            self.docs_json_path = docs_json_in_docs
         self.layout = layout
         
         # Base source root - default to local development path if not provided


### PR DESCRIPTION
## Summary
- Fix SDK doc generator to update `docs/docs.json` (not repo-root `docs.json`) after Mintlify subpath migration
- Run `sync_sdk_reference_nav.py` after auto-gen as a safety net so orphan SDK pages cannot block PraisonAIDocs nav-check again

## Context
PraisonAIDocs auto-merge was blocked because auto-generated SDK reference MDX was pushed without updating navigation. Root cause: generator looked for `docs.json` at repo root while Mintlify config lives at `docs/docs.json`.

## Test plan
- [ ] Merge and verify next `generate-docs.yml` run updates `docs/docs.json`
- [ ] Confirm PraisonAIDocs `nav-check` stays green after auto-gen push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved SDK reference documentation navigation synchronization after documentation generation.
  * Enhanced documentation generation to locate configuration files in the appropriate documentation directory, with a fallback for existing layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->