### PR TITLE
feat: add Serply search tool (web, news, scholar)

### DIFF
--- a/praisonai_tools/tools/serply_tool.py
+++ b/praisonai_tools/tools/serply_tool.py
@@ -1,0 +1,159 @@
+"""Serply Tool for PraisonAI Agents.
+
+Google web, news, and scholar search using the Serply API (https://serply.io).
+API reference: https://serply.io/docs
+
+Usage:
+    from praisonai_tools import SerplyTool
+
+    serply = SerplyTool()
+    results = serply.search("Python programming")
+    papers = serply.scholar("large language models")
+
+Environment Variables:
+    SERPLY_API_KEY: Serply API key
+"""
+
+import os
+import re
+import html
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+from praisonai_tools.tools.base import BaseTool
+
+logger = logging.getLogger(__name__)
+
+SERPLY_BASE_URL = "https://api.serply.io/v1"
+# One Serply page holds at most 10 results; larger values are ignored server-side.
+_MAX_PAGE_SIZE = 10
+
+
+class SerplyTool(BaseTool):
+    """Tool for Google web, news, and scholar search using Serply."""
+
+    name = "serply"
+    description = "Search Google web, news, and scholar results using the Serply API."
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("SERPLY_API_KEY")
+        super().__init__()
+
+    def run(
+        self,
+        action: str = "search",
+        query: Optional[str] = None,
+        max_results: int = 10,
+        **kwargs
+    ) -> Union[str, Dict[str, Any], List[Dict[str, Any]]]:
+        action = action.lower().replace("-", "_")
+
+        if action == "search":
+            return self.search(query=query, max_results=max_results)
+        elif action == "news":
+            return self.news(query=query, max_results=max_results)
+        elif action == "scholar":
+            return self.scholar(query=query, max_results=max_results)
+        else:
+            return {"error": f"Unknown action: {action}"}
+
+    def _request(self, endpoint: str, query: str, num: int = 10) -> Dict:
+        """Make a Serply API request."""
+        try:
+            import requests
+        except ImportError:
+            return {"error": "requests not installed"}
+
+        if not self.api_key:
+            return {"error": "SERPLY_API_KEY not configured"}
+
+        try:
+            response = requests.get(
+                f"{SERPLY_BASE_URL}/{endpoint}/",
+                headers={"X-Api-Key": self.api_key, "Accept": "application/json"},
+                params={"q": query, "num": min(num, _MAX_PAGE_SIZE)},
+                timeout=10,
+            )
+            if not response.ok:
+                return {"error": f"Serply API error {response.status_code}: {response.text[:200]}"}
+            return response.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    def search(self, query: str, max_results: int = 10) -> List[Dict[str, Any]]:
+        """Search Google."""
+        if not query:
+            return [{"error": "query is required"}]
+
+        result = self._request("search", query, max_results)
+        if "error" in result:
+            return [result]
+
+        results = []
+        for item in result.get("results", [])[:max_results]:
+            results.append({
+                "title": item.get("title"),
+                "url": item.get("link"),
+                "snippet": item.get("description"),
+                "position": item.get("position"),
+            })
+        return results
+
+    def news(self, query: str, max_results: int = 10) -> List[Dict[str, Any]]:
+        """Search Google News."""
+        if not query:
+            return [{"error": "query is required"}]
+
+        result = self._request("news", query, max_results)
+        if "error" in result:
+            return [result]
+
+        results = []
+        for item in result.get("entries", [])[:max_results]:
+            source = item.get("source") or {}
+            results.append({
+                "title": item.get("title"),
+                "url": item.get("link"),
+                "source": source.get("title"),
+                "date": item.get("published"),
+                "snippet": " ".join(html.unescape(re.sub(r"<[^>]+>", "", item.get("summary") or "")).split()),
+            })
+        return results
+
+    def scholar(self, query: str, max_results: int = 10) -> List[Dict[str, Any]]:
+        """Search Google Scholar."""
+        if not query:
+            return [{"error": "query is required"}]
+
+        result = self._request("scholar", query, max_results)
+        if "error" in result:
+            return [result]
+
+        results = []
+        for item in result.get("articles", [])[:max_results]:
+            author = item.get("author") or {}
+            citations = (item.get("extras") or {}).get("citations") or {}
+            results.append({
+                "title": item.get("title"),
+                "url": item.get("link"),
+                "authors": author.get("names"),
+                "snippet": item.get("description"),
+                "citations": citations.get("count"),
+                "document_url": (item.get("doc") or {}).get("link"),
+            })
+        return results
+
+
+def serply_search(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
+    """Search Google with Serply."""
+    return SerplyTool().search(query=query, max_results=max_results)
+
+
+def serply_news_search(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
+    """Search Google News with Serply."""
+    return SerplyTool().news(query=query, max_results=max_results)
+
+
+def serply_scholar_search(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
+    """Search Google Scholar with Serply."""
+    return SerplyTool().scholar(query=query, max_results=max_results)

--- a/praisonai_tools/tools/serply_tool.py
+++ b/praisonai_tools/tools/serply_tool.py
@@ -29,6 +29,15 @@ SERPLY_BASE_URL = "https://api.serply.io/v1"
 _MAX_PAGE_SIZE = 10
 
 
+def _page_size(max_results: Any) -> int:
+    """Clamp a requested result count to the 1..10 range the API serves."""
+    try:
+        n = int(max_results)
+    except (TypeError, ValueError):
+        return _MAX_PAGE_SIZE
+    return max(1, min(n, _MAX_PAGE_SIZE))
+
+
 class SerplyTool(BaseTool):
     """Tool for Google web, news, and scholar search using Serply."""
 
@@ -71,7 +80,7 @@ class SerplyTool(BaseTool):
             response = requests.get(
                 f"{SERPLY_BASE_URL}/{endpoint}/",
                 headers={"X-Api-Key": self.api_key, "Accept": "application/json"},
-                params={"q": query, "num": min(num, _MAX_PAGE_SIZE)},
+                params={"q": query, "num": num},
                 timeout=10,
             )
             if not response.ok:
@@ -85,6 +94,7 @@ class SerplyTool(BaseTool):
         if not query:
             return [{"error": "query is required"}]
 
+        max_results = _page_size(max_results)
         result = self._request("search", query, max_results)
         if "error" in result:
             return [result]
@@ -104,6 +114,7 @@ class SerplyTool(BaseTool):
         if not query:
             return [{"error": "query is required"}]
 
+        max_results = _page_size(max_results)
         result = self._request("news", query, max_results)
         if "error" in result:
             return [result]
@@ -125,6 +136,7 @@ class SerplyTool(BaseTool):
         if not query:
             return [{"error": "query is required"}]
 
+        max_results = _page_size(max_results)
         result = self._request("scholar", query, max_results)
         if "error" in result:
             return [result]

--- a/tests/unit/tools/test_serply_tool.py
+++ b/tests/unit/tools/test_serply_tool.py
@@ -1,0 +1,140 @@
+"""Unit tests for the Serply search tool (offline, requests is mocked)."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from praisonai_tools.tools.serply_tool import (
+    SerplyTool,
+    serply_news_search,
+    serply_scholar_search,
+    serply_search,
+)
+
+
+def _response(payload, ok=True, status=200, text=""):
+    resp = MagicMock()
+    resp.ok = ok
+    resp.status_code = status
+    resp.text = text
+    resp.json.return_value = payload
+    return resp
+
+
+class TestSerplyToolConfig:
+    def test_missing_api_key_returns_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = SerplyTool().search("python")
+        assert result == [{"error": "SERPLY_API_KEY not configured"}]
+
+    def test_explicit_api_key_overrides_env(self):
+        with patch.dict(os.environ, {"SERPLY_API_KEY": "env-key"}, clear=True):
+            assert SerplyTool(api_key="explicit").api_key == "explicit"
+
+    def test_query_required(self):
+        assert SerplyTool(api_key="k").search("") == [{"error": "query is required"}]
+
+    def test_unknown_action(self):
+        assert SerplyTool(api_key="k").run(action="images", query="x") == {"error": "Unknown action: images"}
+
+    def test_discoverable_from_package(self):
+        from praisonai_tools.tools import SerplyTool as Discovered
+
+        assert Discovered is SerplyTool
+
+
+class TestSerplySearch:
+    def test_search_calls_api_and_normalizes(self):
+        payload = {
+            "results": [
+                {"title": "Python", "link": "https://python.org", "description": "Official site", "position": 1},
+            ]
+        }
+        with patch("requests.get", return_value=_response(payload)) as get:
+            results = SerplyTool(api_key="k").run(action="search", query="python", max_results=5)
+
+        assert results == [
+            {"title": "Python", "url": "https://python.org", "snippet": "Official site", "position": 1}
+        ]
+        args, kwargs = get.call_args
+        assert args[0] == "https://api.serply.io/v1/search/"
+        assert kwargs["headers"]["X-Api-Key"] == "k"
+        assert kwargs["params"] == {"q": "python", "num": 5}
+
+    def test_page_size_is_capped_at_ten(self):
+        with patch("requests.get", return_value=_response({"results": []})) as get:
+            SerplyTool(api_key="k").search("python", max_results=50)
+        assert get.call_args.kwargs["params"]["num"] == 10
+
+    def test_http_error_is_reported(self):
+        bad = _response({"detail": "Invalid API key"}, ok=False, status=401, text='{"detail":"Invalid API key"}')
+        with patch("requests.get", return_value=bad):
+            results = SerplyTool(api_key="bad").search("python")
+        assert len(results) == 1
+        assert results[0]["error"].startswith("Serply API error 401")
+
+    def test_request_exception_is_reported(self):
+        with patch("requests.get", side_effect=RuntimeError("boom")):
+            assert SerplyTool(api_key="k").search("python") == [{"error": "boom"}]
+
+    def test_module_function(self):
+        with patch("requests.get", return_value=_response({"results": []})):
+            with patch.dict(os.environ, {"SERPLY_API_KEY": "k"}, clear=True):
+                assert serply_search("python") == []
+
+
+class TestSerplyNews:
+    def test_news_slices_and_strips_html(self):
+        entries = [
+            {
+                "title": f"Story {i}",
+                "link": f"https://news.example/{i}",
+                "published": "Wed, 26 Aug 2026 09:00:09 GMT",
+                "source": {"href": "https://example.com", "title": "Example"},
+                "summary": '<a href="https://x">Story</a>&nbsp;&nbsp;text',
+            }
+            for i in range(20)
+        ]
+        with patch("requests.get", return_value=_response({"entries": entries})) as get:
+            with patch.dict(os.environ, {"SERPLY_API_KEY": "k"}, clear=True):
+                results = serply_news_search("quantum", max_results=3)
+
+        assert get.call_args.args[0] == "https://api.serply.io/v1/news/"
+        assert len(results) == 3
+        assert results[0] == {
+            "title": "Story 0",
+            "url": "https://news.example/0",
+            "source": "Example",
+            "date": "Wed, 26 Aug 2026 09:00:09 GMT",
+            "snippet": "Story text",
+        }
+
+
+class TestSerplyScholar:
+    def test_scholar_normalizes_articles(self):
+        payload = {
+            "articles": [
+                {
+                    "title": "Quantum Computing in the NISQ era",
+                    "link": "https://doi.org/10.22331/q-2018-08-06-79",
+                    "description": "John Preskill - Quantum, 2018",
+                    "author": {"names": "John Preskill - Quantum, 2018", "authors": []},
+                    "extras": {"citations": {"count": 8592, "link": "https://openalex.org/..."}},
+                    "doc": {"link": "https://quantum-journal.org/paper.pdf", "type": "PDF"},
+                }
+            ]
+        }
+        with patch("requests.get", return_value=_response(payload)) as get:
+            with patch.dict(os.environ, {"SERPLY_API_KEY": "k"}, clear=True):
+                results = serply_scholar_search("quantum computing", max_results=2)
+
+        assert get.call_args.args[0] == "https://api.serply.io/v1/scholar/"
+        assert results == [
+            {
+                "title": "Quantum Computing in the NISQ era",
+                "url": "https://doi.org/10.22331/q-2018-08-06-79",
+                "authors": "John Preskill - Quantum, 2018",
+                "snippet": "John Preskill - Quantum, 2018",
+                "citations": 8592,
+                "document_url": "https://quantum-journal.org/paper.pdf",
+            }
+        ]

--- a/tests/unit/tools/test_serply_tool.py
+++ b/tests/unit/tools/test_serply_tool.py
@@ -65,6 +65,18 @@ class TestSerplySearch:
             SerplyTool(api_key="k").search("python", max_results=50)
         assert get.call_args.kwargs["params"]["num"] == 10
 
+    def test_negative_max_results_is_clamped_to_one(self):
+        payload = {"results": [{"title": "a", "link": "u", "description": "d", "position": 1}] * 3}
+        with patch("requests.get", return_value=_response(payload)) as get:
+            results = SerplyTool(api_key="k").search("python", max_results=-1)
+        assert get.call_args.kwargs["params"]["num"] == 1
+        assert len(results) == 1
+
+    def test_zero_max_results_is_clamped_to_one(self):
+        with patch("requests.get", return_value=_response({"results": []})) as get:
+            SerplyTool(api_key="k").news("python", max_results=0)
+        assert get.call_args.kwargs["params"]["num"] == 1
+
     def test_http_error_is_reported(self):
         bad = _response({"detail": "Invalid API key"}, ok=False, status=401, text='{"detail":"Invalid API key"}')
         with patch("requests.get", return_value=bad):


### PR DESCRIPTION
## What and why

Adds `SerplyTool` (plus `serply_search`, `serply_news_search`, `serply_scholar_search`) as a new agent-callable search tool backed by the [Serply](https://serply.io) API. Serply returns Google web, news, and scholar results from one key, so agents get a Scholar vertical that the existing search tools here do not cover.

The module follows `serper_tool.py` line for line: `BaseTool` subclass with `run(action=..., query=..., max_results=...)`, `requests` imported lazily inside `_request` (no new dependency and no new extra), and the same normalized `title/url/snippet` result dicts. It is picked up by the automatic discovery in `praisonai_tools/tools/`, so there is no registration to edit. Nothing changes for anyone who does not set `SERPLY_API_KEY`.

Actions:

- `search`: `GET /v1/search/` -> `results[]` (title, url, snippet, position)
- `news`: `GET /v1/news/` -> `entries[]` (title, url, source, date, snippet with the RSS HTML stripped)
- `scholar`: `GET /v1/scholar/` -> `articles[]` (title, url, authors, snippet, citations, document_url)

Page size is capped at 10, which is the largest page the API serves; the news endpoint ignores `num` server-side so the client slices to `max_results`. Non-2xx responses come back as `{"error": "Serply API error <status>: ..."}` in the same shape the other search tools use.

API reference: https://serply.io/docs

## Verification

- `ruff check praisonai_tools tests --ignore E501,E701,E722,F401,F402`: clean
- `pytest tests/unit --ignore=tests/unit/video -q --timeout=120 -x`: 187 passed, 6 skipped (175 before this change)
- `pytest tests -q`: 632 passed, 16 skipped, 1 failed; the failure (`test_marketplace_agentic_agentfolio.py::test_agentfolio_agentic`) also fails on a clean `main` checkout and is unrelated
- `from praisonai_tools.catalogue import list_tools` lists `SerplyTool` with the class description as its summary; `from praisonai_tools.tools import SerplyTool` resolves lazily
- Live check with a real key: all three actions return results; an invalid key returns the 401 error dict

Tests mock `requests.get`, so the suite stays offline.

The change is two files and about 300 lines, which is larger than a typical small PR here. Roughly half of that is the unit test module; the tool itself is the same size as `serper_tool.py`.

## Disclosure

I work with Serply. Happy to adjust the action set, result fields, or naming if you would prefer a different shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Serply-powered web, news, and scholarly search capabilities.
  * Supports configurable result limits from 1 to 10.
  * Provides structured feedback for missing configuration, request failures, and invalid actions.

* **Bug Fixes**
  * Search results are normalized into a consistent format.
  * Redirect handling prevents sensitive request headers from being forwarded.

* **Tests**
  * Added coverage for search behavior, configuration, result limits, errors, redirects, and response normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->