### PR TITLE
feat: add HubSpot CRM integration tool

### DIFF
--- a/praisonai_tools/catalogue.py
+++ b/praisonai_tools/catalogue.py
@@ -55,6 +55,7 @@ _MODULE_EXTRAS = {
     "langextract_tool": ("langextract",),
     "swarmscore_tool": ("swarmscore",),
     "composio_tool": ("composio",),
+    "hubspot_tool": ("hubspot",),
 }
 
 

--- a/praisonai_tools/tools/hubspot_tool.py
+++ b/praisonai_tools/tools/hubspot_tool.py
@@ -1,0 +1,649 @@
+"""HubSpot CRM Tool for PraisonAI Agents.
+
+Manage HubSpot CRM — contacts, companies, deals, pipelines, and activity logging
+via the HubSpot REST API v3.
+
+Usage:
+    from praisonai_tools import HubSpotTool
+
+    hs = HubSpotTool()  # Uses HUBSPOT_ACCESS_TOKEN env var
+
+    # Create a contact (returns the created id directly - no re-search needed)
+    contact = hs.create_contact(
+        email="alice@example.com",
+        firstname="Alice",
+        lastname="Smith",
+        company="Acme Corp",
+    )
+
+    # Move a deal through the pipeline
+    hs.move_deal_stage(deal_id="123", stage_id="closedwon")
+
+Environment Variables:
+    HUBSPOT_ACCESS_TOKEN: Private App access token (recommended, sent as Bearer)
+
+Notes:
+    * Activities (calls/emails/meetings/notes) use the v3 CRM object endpoints
+      (``/crm/v3/objects/calls`` etc.), NOT the legacy ``/engagements/v1`` API,
+      so the activity timeline links correctly to v3 contacts/deals.
+    * The access token is never logged and is masked in error messages.
+"""
+
+import os
+import time
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+from praisonai_tools.tools.base import BaseTool
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.hubapi.com"
+
+# HubSpot numeric association type IDs (default/unlabeled associations).
+ASSOC_CONTACT_TO_COMPANY = 279
+ASSOC_DEAL_TO_CONTACT = 3
+ASSOC_DEAL_TO_COMPANY = 5
+ASSOC_NOTE_TO_CONTACT = 202
+ASSOC_NOTE_TO_DEAL = 214
+ASSOC_NOTE_TO_COMPANY = 190
+ASSOC_CALL_TO_CONTACT = 194
+ASSOC_EMAIL_TO_CONTACT = 198
+ASSOC_MEETING_TO_CONTACT = 200
+
+
+class HubSpotTool(BaseTool):
+    """Tool for managing HubSpot CRM objects and activities."""
+
+    name = "hubspot"
+    description = "Manage HubSpot CRM — contacts, companies, deals, pipelines, activities."
+
+    def __init__(self, access_token: Optional[str] = None, max_retries: int = 3):
+        self.access_token = access_token or os.getenv("HUBSPOT_ACCESS_TOKEN")
+        self.max_retries = max_retries
+        super().__init__()
+
+    # ── HTTP client ─────────────────────────────────────────────────────
+    def _mask(self, text: str) -> str:
+        """Redact the access token if it ever appears in a message."""
+        if self.access_token and text:
+            return text.replace(self.access_token, "***")
+        return text
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        json_body: Optional[Dict] = None,
+        params: Optional[Dict] = None,
+    ) -> Dict[str, Any]:
+        """Perform an authenticated request with 429 retry + backoff."""
+        try:
+            import requests
+        except ImportError:
+            return {"error": "requests not installed. Install with: pip install requests"}
+
+        if not self.access_token:
+            return {"error": "HUBSPOT_ACCESS_TOKEN required"}
+
+        url = path if path.startswith("http") else f"{BASE_URL}{path}"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                resp = requests.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=json_body,
+                    params=params,
+                    timeout=30,
+                )
+            except Exception as e:  # network-level failure
+                return {"error": self._mask(str(e))}
+
+            if resp.status_code == 429 and attempt < self.max_retries:
+                retry_after = resp.headers.get("Retry-After")
+                delay = float(retry_after) if retry_after else 2 ** attempt
+                time.sleep(delay)
+                continue
+
+            if resp.status_code == 204 or not resp.content:
+                return {"success": True, "status_code": resp.status_code}
+
+            try:
+                data = resp.json()
+            except ValueError:
+                data = {"raw": resp.text}
+
+            if resp.status_code >= 400:
+                message = data.get("message") if isinstance(data, dict) else str(data)
+                return {
+                    "error": self._mask(message or f"HTTP {resp.status_code}"),
+                    "status_code": resp.status_code,
+                }
+            return data
+
+        return {"error": "Rate limited (429) after retries", "status_code": 429}
+
+    # ── Core dispatch ───────────────────────────────────────────────────
+    def run(self, action: str = "search_crm", **kwargs) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        action = action.lower().replace("-", "_")
+        dispatch = {
+            "create_contact": self.create_contact,
+            "get_contact": self.get_contact,
+            "update_contact": self.update_contact,
+            "search_contacts": self.search_contacts,
+            "delete_contact": self.delete_contact,
+            "list_contacts": self.list_contacts,
+            "create_company": self.create_company,
+            "get_company": self.get_company,
+            "update_company": self.update_company,
+            "search_companies": self.search_companies,
+            "associate_contact_to_company": self.associate_contact_to_company,
+            "create_deal": self.create_deal,
+            "get_deal": self.get_deal,
+            "update_deal": self.update_deal,
+            "move_deal_stage": self.move_deal_stage,
+            "list_deals": self.list_deals,
+            "associate_deal_with_contact": self.associate_deal_with_contact,
+            "associate_deal_with_company": self.associate_deal_with_company,
+            "list_pipelines": self.list_pipelines,
+            "get_pipeline_stages": self.get_pipeline_stages,
+            "log_call": self.log_call,
+            "log_email": self.log_email,
+            "log_meeting": self.log_meeting,
+            "create_note": self.create_note,
+            "list_activities": self.list_activities,
+            "search_crm": self.search_crm,
+            "list_properties": self.list_properties,
+            "create_property": self.create_property,
+        }
+        fn = dispatch.get(action)
+        if not fn:
+            return {"error": f"Unknown action: {action}"}
+        return fn(**kwargs)
+
+    # ── Contact Operations ──────────────────────────────────────────────
+    def create_contact(
+        self,
+        email: str,
+        firstname: Optional[str] = None,
+        lastname: Optional[str] = None,
+        phone: Optional[str] = None,
+        company: Optional[str] = None,
+        **custom_props,
+    ) -> Dict[str, Any]:
+        """Create a new HubSpot contact. Returns the created id directly."""
+        if not email:
+            return {"error": "email required"}
+        props: Dict[str, Any] = {"email": email}
+        for key, val in (
+            ("firstname", firstname),
+            ("lastname", lastname),
+            ("phone", phone),
+            ("company", company),
+        ):
+            if val is not None:
+                props[key] = val
+        props.update(custom_props)
+        return self._request("POST", "/crm/v3/objects/contacts", {"properties": props})
+
+    def get_contact(
+        self, contact_id: str, properties: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """Get contact by ID with selected properties."""
+        if not contact_id:
+            return {"error": "contact_id required"}
+        params = {"properties": ",".join(properties)} if properties else None
+        return self._request("GET", f"/crm/v3/objects/contacts/{contact_id}", params=params)
+
+    def update_contact(self, contact_id: str, **properties) -> Dict[str, Any]:
+        """Update contact properties."""
+        if not contact_id:
+            return {"error": "contact_id required"}
+        if not properties:
+            return {"error": "no properties to update"}
+        return self._request(
+            "PATCH", f"/crm/v3/objects/contacts/{contact_id}", {"properties": properties}
+        )
+
+    def search_contacts(
+        self,
+        query: Optional[str] = None,
+        filters: Optional[List[Dict]] = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Search contacts by query string or filter groups."""
+        return self._search("contacts", query=query, filters=filters, limit=limit)
+
+    def delete_contact(self, contact_id: str) -> Dict[str, Any]:
+        """Archive (soft-delete) a contact."""
+        if not contact_id:
+            return {"error": "contact_id required"}
+        return self._request("DELETE", f"/crm/v3/objects/contacts/{contact_id}")
+
+    def list_contacts(self, limit: int = 100, after: Optional[str] = None) -> Dict[str, Any]:
+        """List contacts with cursor pagination. Returns {results, paging}."""
+        params: Dict[str, Any] = {"limit": limit}
+        if after:
+            params["after"] = after
+        return self._request("GET", "/crm/v3/objects/contacts", params=params)
+
+    # ── Company Operations ──────────────────────────────────────────────
+    def create_company(
+        self,
+        name: str,
+        domain: Optional[str] = None,
+        industry: Optional[str] = None,
+        **custom_props,
+    ) -> Dict[str, Any]:
+        """Create a new company."""
+        if not name:
+            return {"error": "name required"}
+        props: Dict[str, Any] = {"name": name}
+        if domain is not None:
+            props["domain"] = domain
+        if industry is not None:
+            props["industry"] = industry
+        props.update(custom_props)
+        return self._request("POST", "/crm/v3/objects/companies", {"properties": props})
+
+    def get_company(
+        self, company_id: str, properties: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """Get company by ID."""
+        if not company_id:
+            return {"error": "company_id required"}
+        params = {"properties": ",".join(properties)} if properties else None
+        return self._request("GET", f"/crm/v3/objects/companies/{company_id}", params=params)
+
+    def update_company(self, company_id: str, **properties) -> Dict[str, Any]:
+        """Update company properties."""
+        if not company_id:
+            return {"error": "company_id required"}
+        if not properties:
+            return {"error": "no properties to update"}
+        return self._request(
+            "PATCH", f"/crm/v3/objects/companies/{company_id}", {"properties": properties}
+        )
+
+    def search_companies(
+        self,
+        query: Optional[str] = None,
+        filters: Optional[List[Dict]] = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Search companies."""
+        return self._search("companies", query=query, filters=filters, limit=limit)
+
+    def associate_contact_to_company(
+        self, contact_id: str, company_id: str
+    ) -> Dict[str, Any]:
+        """Create contact-company association."""
+        if not contact_id or not company_id:
+            return {"error": "contact_id and company_id required"}
+        return self._associate(
+            "contacts", contact_id, "companies", company_id, ASSOC_CONTACT_TO_COMPANY
+        )
+
+    # ── Deal Operations ─────────────────────────────────────────────────
+    def create_deal(
+        self,
+        dealname: str,
+        pipeline: str = "default",
+        dealstage: Optional[str] = None,
+        amount: Optional[float] = None,
+        closedate: Optional[str] = None,
+        **custom_props,
+    ) -> Dict[str, Any]:
+        """Create a new deal. Returns the created id directly."""
+        if not dealname:
+            return {"error": "dealname required"}
+        props: Dict[str, Any] = {"dealname": dealname, "pipeline": pipeline}
+        if dealstage is not None:
+            props["dealstage"] = dealstage
+        if amount is not None:
+            props["amount"] = amount
+        if closedate is not None:
+            props["closedate"] = closedate
+        props.update(custom_props)
+        return self._request("POST", "/crm/v3/objects/deals", {"properties": props})
+
+    def get_deal(self, deal_id: str, properties: Optional[List[str]] = None) -> Dict[str, Any]:
+        """Get deal by ID."""
+        if not deal_id:
+            return {"error": "deal_id required"}
+        params = {"properties": ",".join(properties)} if properties else None
+        return self._request("GET", f"/crm/v3/objects/deals/{deal_id}", params=params)
+
+    def update_deal(self, deal_id: str, **properties) -> Dict[str, Any]:
+        """Update deal properties."""
+        if not deal_id:
+            return {"error": "deal_id required"}
+        if not properties:
+            return {"error": "no properties to update"}
+        return self._request(
+            "PATCH", f"/crm/v3/objects/deals/{deal_id}", {"properties": properties}
+        )
+
+    def move_deal_stage(self, deal_id: str, stage_id: str) -> Dict[str, Any]:
+        """Move deal to a specific pipeline stage."""
+        if not deal_id or not stage_id:
+            return {"error": "deal_id and stage_id required"}
+        return self._request(
+            "PATCH",
+            f"/crm/v3/objects/deals/{deal_id}",
+            {"properties": {"dealstage": stage_id}},
+        )
+
+    def list_deals(
+        self,
+        pipeline: Optional[str] = None,
+        stage: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """List deals, optionally filtered by pipeline and stage."""
+        filters = []
+        if pipeline:
+            filters.append({"propertyName": "pipeline", "operator": "EQ", "value": pipeline})
+        if stage:
+            filters.append({"propertyName": "dealstage", "operator": "EQ", "value": stage})
+        if filters:
+            return self._search("deals", filters=filters, limit=limit)
+        result = self._request("GET", "/crm/v3/objects/deals", params={"limit": limit})
+        if isinstance(result, dict) and "error" in result:
+            return [result]
+        return result.get("results", []) if isinstance(result, dict) else result
+
+    def associate_deal_with_contact(self, deal_id: str, contact_id: str) -> Dict[str, Any]:
+        """Associate a deal with a contact."""
+        if not deal_id or not contact_id:
+            return {"error": "deal_id and contact_id required"}
+        return self._associate(
+            "deals", deal_id, "contacts", contact_id, ASSOC_DEAL_TO_CONTACT
+        )
+
+    def associate_deal_with_company(self, deal_id: str, company_id: str) -> Dict[str, Any]:
+        """Associate a deal with a company."""
+        if not deal_id or not company_id:
+            return {"error": "deal_id and company_id required"}
+        return self._associate(
+            "deals", deal_id, "companies", company_id, ASSOC_DEAL_TO_COMPANY
+        )
+
+    # ── Pipeline Operations ─────────────────────────────────────────────
+    def list_pipelines(self, object_type: str = "deals") -> List[Dict[str, Any]]:
+        """List all pipelines for an object type."""
+        result = self._request("GET", f"/crm/v3/pipelines/{object_type}")
+        if isinstance(result, dict) and "error" in result:
+            return [result]
+        return result.get("results", []) if isinstance(result, dict) else result
+
+    def get_pipeline_stages(
+        self, pipeline_id: str, object_type: str = "deals"
+    ) -> List[Dict[str, Any]]:
+        """Get stages for a specific pipeline."""
+        if not pipeline_id:
+            return [{"error": "pipeline_id required"}]
+        result = self._request(
+            "GET", f"/crm/v3/pipelines/{object_type}/{pipeline_id}/stages"
+        )
+        if isinstance(result, dict) and "error" in result:
+            return [result]
+        return result.get("results", []) if isinstance(result, dict) else result
+
+    # ── Activity Logging (v3 CRM objects) ───────────────────────────────
+    def log_call(
+        self,
+        contact_id: str,
+        body: str,
+        duration_ms: Optional[int] = None,
+        direction: str = "OUTBOUND",
+    ) -> Dict[str, Any]:
+        """Log a call activity on a contact (v3 /crm/v3/objects/calls)."""
+        if not contact_id or not body:
+            return {"error": "contact_id and body required"}
+        props: Dict[str, Any] = {
+            "hs_call_body": body,
+            "hs_call_direction": direction,
+            "hs_timestamp": self._now_ms(),
+        }
+        if duration_ms is not None:
+            props["hs_call_duration"] = duration_ms
+        return self._create_activity(
+            "calls", props, contact_id, ASSOC_CALL_TO_CONTACT
+        )
+
+    def log_email(
+        self,
+        contact_id: str,
+        subject: str,
+        body: str,
+        direction: str = "OUTBOUND",
+    ) -> Dict[str, Any]:
+        """Log an email activity (v3 /crm/v3/objects/emails)."""
+        if not contact_id or not subject:
+            return {"error": "contact_id and subject required"}
+        props = {
+            "hs_email_subject": subject,
+            "hs_email_text": body,
+            "hs_email_direction": (
+                "EMAIL" if direction.upper() == "OUTBOUND" else "INCOMING_EMAIL"
+            ),
+            "hs_timestamp": self._now_ms(),
+        }
+        return self._create_activity(
+            "emails", props, contact_id, ASSOC_EMAIL_TO_CONTACT
+        )
+
+    def log_meeting(
+        self,
+        contact_id: str,
+        title: str,
+        body: Optional[str] = None,
+        start_time: Optional[str] = None,
+        duration_ms: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Log a meeting (v3 /crm/v3/objects/meetings)."""
+        if not contact_id or not title:
+            return {"error": "contact_id and title required"}
+        props: Dict[str, Any] = {
+            "hs_meeting_title": title,
+            "hs_timestamp": start_time or self._now_ms(),
+        }
+        if body is not None:
+            props["hs_meeting_body"] = body
+        if duration_ms is not None:
+            props["hs_meeting_end_time"] = None  # duration handled by end time
+        return self._create_activity(
+            "meetings", props, contact_id, ASSOC_MEETING_TO_CONTACT
+        )
+
+    def create_note(
+        self,
+        body: str,
+        contact_id: Optional[str] = None,
+        deal_id: Optional[str] = None,
+        company_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a note associated with a CRM object (v3 /crm/v3/objects/notes)."""
+        if not body:
+            return {"error": "body required"}
+        associations = []
+        if contact_id:
+            associations.append(self._assoc_block("contacts", contact_id, ASSOC_NOTE_TO_CONTACT))
+        if deal_id:
+            associations.append(self._assoc_block("deals", deal_id, ASSOC_NOTE_TO_DEAL))
+        if company_id:
+            associations.append(self._assoc_block("companies", company_id, ASSOC_NOTE_TO_COMPANY))
+        payload: Dict[str, Any] = {
+            "properties": {"hs_note_body": body, "hs_timestamp": self._now_ms()}
+        }
+        if associations:
+            payload["associations"] = associations
+        return self._request("POST", "/crm/v3/objects/notes", payload)
+
+    def list_activities(
+        self,
+        contact_id: Optional[str] = None,
+        deal_id: Optional[str] = None,
+        activity_types: Optional[List[str]] = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """List activity engagements associated with a contact or deal."""
+        if not contact_id and not deal_id:
+            return [{"error": "contact_id or deal_id required"}]
+        from_type = "contacts" if contact_id else "deals"
+        from_id = contact_id or deal_id
+        types = activity_types or ["notes", "calls", "emails", "meetings"]
+        activities: List[Dict[str, Any]] = []
+        for to_type in types:
+            result = self._request(
+                "GET", f"/crm/v3/objects/{from_type}/{from_id}/associations/{to_type}"
+            )
+            if isinstance(result, dict) and "results" in result:
+                for item in result["results"][:limit]:
+                    activities.append({"type": to_type, "id": item.get("toObjectId") or item.get("id")})
+        return activities[:limit]
+
+    # ── Unified Search ──────────────────────────────────────────────────
+    def search_crm(
+        self,
+        query: str,
+        object_types: Optional[List[str]] = None,
+        limit: int = 10,
+    ) -> Dict[str, Any]:
+        """Search across contacts, companies, and deals simultaneously."""
+        if not query:
+            return {"error": "query required"}
+        types = object_types or ["contacts", "companies", "deals"]
+        results: Dict[str, Any] = {}
+        for object_type in types:
+            results[object_type] = self._search(object_type, query=query, limit=limit)
+        return results
+
+    # ── Properties ──────────────────────────────────────────────────────
+    def list_properties(self, object_type: str = "contacts") -> List[Dict[str, Any]]:
+        """List all properties for a CRM object type."""
+        result = self._request("GET", f"/crm/v3/properties/{object_type}")
+        if isinstance(result, dict) and "error" in result:
+            return [result]
+        return result.get("results", []) if isinstance(result, dict) else result
+
+    def create_property(
+        self,
+        object_type: str,
+        name: str,
+        label: str,
+        field_type: str,
+        group_name: str = "contactinformation",
+    ) -> Dict[str, Any]:
+        """Create a custom property."""
+        if not name or not label:
+            return {"error": "name and label required"}
+        payload = {
+            "name": name,
+            "label": label,
+            "type": "string",
+            "fieldType": field_type,
+            "groupName": group_name,
+        }
+        return self._request("POST", f"/crm/v3/properties/{object_type}", payload)
+
+    # ── Internal helpers ────────────────────────────────────────────────
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.time() * 1000)
+
+    @staticmethod
+    def _assoc_block(to_type: str, to_id: str, type_id: int) -> Dict[str, Any]:
+        return {
+            "to": {"id": to_id},
+            "types": [
+                {
+                    "associationCategory": "HUBSPOT_DEFINED",
+                    "associationTypeId": type_id,
+                }
+            ],
+        }
+
+    def _associate(
+        self, from_type: str, from_id: str, to_type: str, to_id: str, type_id: int
+    ) -> Dict[str, Any]:
+        payload = [
+            {
+                "associationCategory": "HUBSPOT_DEFINED",
+                "associationTypeId": type_id,
+            }
+        ]
+        return self._request(
+            "PUT",
+            f"/crm/v3/objects/{from_type}/{from_id}/associations/{to_type}/{to_id}",
+            payload,
+        )
+
+    def _create_activity(
+        self, object_type: str, props: Dict[str, Any], contact_id: str, type_id: int
+    ) -> Dict[str, Any]:
+        payload = {
+            "properties": {k: v for k, v in props.items() if v is not None},
+            "associations": [self._assoc_block("contacts", contact_id, type_id)],
+        }
+        return self._request("POST", f"/crm/v3/objects/{object_type}", payload)
+
+    def _search(
+        self,
+        object_type: str,
+        query: Optional[str] = None,
+        filters: Optional[List[Dict]] = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        payload: Dict[str, Any] = {"limit": limit}
+        if query:
+            payload["query"] = query
+        if filters:
+            payload["filterGroups"] = [{"filters": filters}]
+        result = self._request(
+            "POST", f"/crm/v3/objects/{object_type}/search", payload
+        )
+        if isinstance(result, dict) and "error" in result:
+            return [result]
+        return result.get("results", []) if isinstance(result, dict) else result
+
+
+# ── Standalone tool functions (for direct @tool-style agent use) ────────
+def hubspot_search_contacts(query: str) -> List[Dict[str, Any]]:
+    """Search HubSpot contacts."""
+    return HubSpotTool().search_contacts(query=query)
+
+
+def hubspot_create_contact(
+    email: str, firstname: str = "", lastname: str = "", company: str = ""
+) -> Dict[str, Any]:
+    """Create a HubSpot contact."""
+    return HubSpotTool().create_contact(
+        email=email, firstname=firstname, lastname=lastname, company=company
+    )
+
+
+def hubspot_create_deal(
+    dealname: str, pipeline: str = "default", dealstage: str = "", amount: float = 0
+) -> Dict[str, Any]:
+    """Create a HubSpot deal."""
+    return HubSpotTool().create_deal(
+        dealname=dealname, pipeline=pipeline, dealstage=dealstage, amount=amount
+    )
+
+
+def hubspot_move_deal_stage(deal_id: str, stage_id: str) -> Dict[str, Any]:
+    """Move a HubSpot deal to a new stage."""
+    return HubSpotTool().move_deal_stage(deal_id=deal_id, stage_id=stage_id)
+
+
+def hubspot_log_call(contact_id: str, body: str) -> Dict[str, Any]:
+    """Log a call on a HubSpot contact."""
+    return HubSpotTool().log_call(contact_id=contact_id, body=body)

--- a/praisonai_tools/tools/hubspot_tool.py
+++ b/praisonai_tools/tools/hubspot_tool.py
@@ -554,10 +554,22 @@ class HubSpotTool(BaseTool):
         """Create a custom property."""
         if not name or not label:
             return {"error": "name and label required"}
+        # HubSpot needs both the data ``type`` and the widget ``fieldType``.
+        # Derive a sensible ``type`` from the field type so numeric/date/enum
+        # properties aren't silently created as strings.
+        field_to_type = {
+            "number": "number",
+            "date": "date",
+            "datetime": "datetime",
+            "booleancheckbox": "bool",
+            "checkbox": "enumeration",
+            "select": "enumeration",
+            "radio": "enumeration",
+        }
         payload = {
             "name": name,
             "label": label,
-            "type": "string",
+            "type": field_to_type.get(field_type, "string"),
             "fieldType": field_type,
             "groupName": group_name,
         }

--- a/praisonai_tools/tools/hubspot_tool.py
+++ b/praisonai_tools/tools/hubspot_tool.py
@@ -107,7 +107,12 @@ class HubSpotTool(BaseTool):
 
             if resp.status_code == 429 and attempt < self.max_retries:
                 retry_after = resp.headers.get("Retry-After")
-                delay = float(retry_after) if retry_after else 2 ** attempt
+                # Retry-After may be seconds (numeric) or an HTTP-date; fall back
+                # to exponential backoff when it isn't a plain number.
+                try:
+                    delay = float(retry_after) if retry_after else 2 ** attempt
+                except ValueError:
+                    delay = 2 ** attempt
                 time.sleep(delay)
                 continue
 
@@ -458,7 +463,11 @@ class HubSpotTool(BaseTool):
         if body is not None:
             props["hs_meeting_body"] = body
         if duration_ms is not None:
-            props["hs_meeting_end_time"] = None  # duration handled by end time
+            start_ms = self._to_ms(props["hs_timestamp"])
+            if start_ms is None:
+                start_ms = self._now_ms()
+            props["hs_meeting_start_time"] = start_ms
+            props["hs_meeting_end_time"] = start_ms + duration_ms
         return self._create_activity(
             "meetings", props, contact_id, ASSOC_MEETING_TO_CONTACT
         )
@@ -560,6 +569,14 @@ class HubSpotTool(BaseTool):
         return int(time.time() * 1000)
 
     @staticmethod
+    def _to_ms(value: Any) -> Optional[int]:
+        """Convert an epoch-millisecond timestamp to int; None if not numeric."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
     def _assoc_block(to_type: str, to_id: str, type_id: int) -> Dict[str, Any]:
         return {
             "to": {"id": to_id},
@@ -574,16 +591,11 @@ class HubSpotTool(BaseTool):
     def _associate(
         self, from_type: str, from_id: str, to_type: str, to_id: str, type_id: int
     ) -> Dict[str, Any]:
-        payload = [
-            {
-                "associationCategory": "HUBSPOT_DEFINED",
-                "associationTypeId": type_id,
-            }
-        ]
+        # The v3 individual-association endpoint takes the association type id in
+        # the URL path; it must not be sent in the request body.
         return self._request(
             "PUT",
-            f"/crm/v3/objects/{from_type}/{from_id}/associations/{to_type}/{to_id}",
-            payload,
+            f"/crm/v3/objects/{from_type}/{from_id}/associations/{to_type}/{to_id}/{type_id}",
         )
 
     def _create_activity(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ meeting = [
     "openai>=1.12.0",
     "chromadb>=0.4.0",
 ]
+hubspot = [
+    "requests>=2.28.0",
+]
 
 [project.urls]
 Homepage = "https://docs.praison.ai"

--- a/tests/unit/tools/test_hubspot_tool.py
+++ b/tests/unit/tools/test_hubspot_tool.py
@@ -1,0 +1,186 @@
+"""Unit tests for HubSpotTool."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from praisonai_tools.tools.hubspot_tool import (
+    HubSpotTool,
+    hubspot_create_contact,
+    hubspot_search_contacts,
+)
+
+
+def _mock_response(payload, status_code=200, headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.content = b"{}" if payload is not None else b""
+    resp.json.return_value = payload
+    resp.text = ""
+    return resp
+
+
+# ── _request wiring ─────────────────────────────────────────────────
+class TestRequest:
+    def test_missing_token_returns_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            tool = HubSpotTool()
+            assert tool._request("GET", "/x") == {"error": "HUBSPOT_ACCESS_TOKEN required"}
+
+    def test_sends_bearer_header(self):
+        tool = HubSpotTool(access_token="pat-123")
+        with patch("requests.request") as req:
+            req.return_value = _mock_response({"ok": True})
+            tool._request("GET", "/crm/v3/objects/contacts")
+            headers = req.call_args.kwargs["headers"]
+            assert headers["Authorization"] == "Bearer pat-123"
+
+    def test_masks_token_in_error(self):
+        tool = HubSpotTool(access_token="secret-tok")
+        with patch("requests.request", side_effect=RuntimeError("boom secret-tok leaked")):
+            result = tool._request("GET", "/x")
+        assert "secret-tok" not in result["error"]
+        assert "***" in result["error"]
+
+    def test_retries_on_429_then_succeeds(self):
+        tool = HubSpotTool(access_token="x", max_retries=2)
+        responses = [
+            _mock_response(None, status_code=429, headers={"Retry-After": "0"}),
+            _mock_response({"ok": True}),
+        ]
+        with patch("requests.request", side_effect=responses), patch("time.sleep"):
+            result = tool._request("GET", "/x")
+        assert result == {"ok": True}
+
+    def test_http_error_returns_message(self):
+        tool = HubSpotTool(access_token="x")
+        with patch(
+            "requests.request",
+            return_value=_mock_response({"message": "Invalid input"}, status_code=400),
+        ):
+            result = tool._request("POST", "/x", {})
+        assert result["error"] == "Invalid input"
+        assert result["status_code"] == 400
+
+
+# ── Contacts ────────────────────────────────────────────────────────
+class TestContacts:
+    def test_create_contact_requires_email(self):
+        tool = HubSpotTool(access_token="x")
+        assert tool.create_contact(email="") == {"error": "email required"}
+
+    def test_create_contact_builds_properties(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"id": "1"})) as req:
+            tool.create_contact(email="a@b.com", firstname="Al", company="Acme")
+        body = req.call_args.kwargs["json"]
+        assert body["properties"]["email"] == "a@b.com"
+        assert body["properties"]["firstname"] == "Al"
+        assert body["properties"]["company"] == "Acme"
+
+    def test_update_contact_requires_props(self):
+        tool = HubSpotTool(access_token="x")
+        assert tool.update_contact(contact_id="1") == {"error": "no properties to update"}
+
+    def test_search_contacts_returns_results(self):
+        tool = HubSpotTool(access_token="x")
+        payload = {"results": [{"id": "1"}, {"id": "2"}]}
+        with patch("requests.request", return_value=_mock_response(payload)):
+            out = tool.search_contacts(query="alice")
+        assert len(out) == 2
+
+    def test_delete_contact_requires_id(self):
+        tool = HubSpotTool(access_token="x")
+        assert tool.delete_contact(contact_id="") == {"error": "contact_id required"}
+
+
+# ── Deals ───────────────────────────────────────────────────────────
+class TestDeals:
+    def test_create_deal_requires_name(self):
+        tool = HubSpotTool(access_token="x")
+        assert tool.create_deal(dealname="") == {"error": "dealname required"}
+
+    def test_move_deal_stage_patches_dealstage(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"id": "1"})) as req:
+            tool.move_deal_stage(deal_id="1", stage_id="closedwon")
+        assert req.call_args.kwargs["json"]["properties"]["dealstage"] == "closedwon"
+        assert req.call_args.args[0] == "PATCH"
+
+    def test_associate_deal_with_contact_uses_type_id_3(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"ok": True})) as req:
+            tool.associate_deal_with_contact(deal_id="2", contact_id="1")
+        url = req.call_args.args[1]
+        assert "/deals/2/associations/contacts/1" in url
+        assert req.call_args.kwargs["json"][0]["associationTypeId"] == 3
+
+
+# ── Activities use v3 CRM objects (not legacy /engagements/v1) ───────
+class TestActivities:
+    def test_log_call_hits_v3_calls_endpoint(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"id": "3"})) as req:
+            tool.log_call(contact_id="1", body="Discovery call")
+        assert req.call_args.args[1].endswith("/crm/v3/objects/calls")
+        body = req.call_args.kwargs["json"]
+        assert body["properties"]["hs_call_body"] == "Discovery call"
+        assert body["associations"][0]["to"]["id"] == "1"
+
+    def test_create_note_associates_multiple_objects(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"id": "5"})) as req:
+            tool.create_note(body="note", contact_id="1", deal_id="2")
+        assocs = req.call_args.kwargs["json"]["associations"]
+        assert len(assocs) == 2
+
+
+# ── Pipelines ───────────────────────────────────────────────────────
+class TestPipelines:
+    def test_list_pipelines_returns_results(self):
+        tool = HubSpotTool(access_token="x")
+        with patch(
+            "requests.request",
+            return_value=_mock_response({"results": [{"id": "default"}]}),
+        ):
+            out = tool.list_pipelines()
+        assert out == [{"id": "default"}]
+
+
+# ── search_crm ──────────────────────────────────────────────────────
+class TestSearchCrm:
+    def test_requires_query(self):
+        tool = HubSpotTool(access_token="x")
+        assert tool.search_crm(query="") == {"error": "query required"}
+
+    def test_searches_all_object_types(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"results": []})):
+            out = tool.search_crm(query="acme")
+        assert set(out.keys()) == {"contacts", "companies", "deals"}
+
+
+# ── run() dispatcher ────────────────────────────────────────────────
+class TestRunDispatcher:
+    def test_unknown_action(self):
+        tool = HubSpotTool(access_token="x")
+        assert tool.run(action="bogus") == {"error": "Unknown action: bogus"}
+
+    def test_routes_create_contact(self):
+        tool = HubSpotTool(access_token="x")
+        with patch.object(tool, "create_contact", return_value={"ok": True}) as m:
+            tool.run(action="create-contact", email="a@b.com")
+        m.assert_called_once_with(email="a@b.com")
+
+
+# ── Standalone helpers ──────────────────────────────────────────────
+class TestStandaloneHelpers:
+    def test_search_contacts_helper(self):
+        with patch.object(HubSpotTool, "search_contacts", return_value=["x"]) as m:
+            assert hubspot_search_contacts(query="a") == ["x"]
+        m.assert_called_once_with(query="a")
+
+    def test_create_contact_helper(self):
+        with patch.object(HubSpotTool, "create_contact", return_value={"id": "1"}) as m:
+            hubspot_create_contact(email="a@b.com", firstname="Al")
+        m.assert_called_once_with(email="a@b.com", firstname="Al", lastname="", company="")

--- a/tests/unit/tools/test_hubspot_tool.py
+++ b/tests/unit/tools/test_hubspot_tool.py
@@ -175,6 +175,38 @@ class TestPipelines:
         assert out == [{"id": "default"}]
 
 
+# ── properties ──────────────────────────────────────────────────────
+class TestProperties:
+    def test_create_property_derives_type_from_field_type(self):
+        tool = HubSpotTool(access_token="x")
+        with patch(
+            "requests.request", return_value=_mock_response({"name": "score"})
+        ) as req:
+            tool.create_property(
+                object_type="contacts",
+                name="score",
+                label="Score",
+                field_type="number",
+            )
+        body = req.call_args.kwargs["json"]
+        assert body["type"] == "number"
+        assert body["fieldType"] == "number"
+
+    def test_create_property_defaults_type_to_string(self):
+        tool = HubSpotTool(access_token="x")
+        with patch(
+            "requests.request", return_value=_mock_response({"name": "note"})
+        ) as req:
+            tool.create_property(
+                object_type="contacts",
+                name="note",
+                label="Note",
+                field_type="text",
+            )
+        body = req.call_args.kwargs["json"]
+        assert body["type"] == "string"
+
+
 # ── search_crm ──────────────────────────────────────────────────────
 class TestSearchCrm:
     def test_requires_query(self):

--- a/tests/unit/tools/test_hubspot_tool.py
+++ b/tests/unit/tools/test_hubspot_tool.py
@@ -52,6 +52,22 @@ class TestRequest:
             result = tool._request("GET", "/x")
         assert result == {"ok": True}
 
+    def test_retry_after_http_date_falls_back_to_backoff(self):
+        # A non-numeric Retry-After (HTTP-date form) must not crash the request.
+        tool = HubSpotTool(access_token="x", max_retries=1)
+        responses = [
+            _mock_response(
+                None,
+                status_code=429,
+                headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+            ),
+            _mock_response({"ok": True}),
+        ]
+        with patch("requests.request", side_effect=responses), patch("time.sleep") as slp:
+            result = tool._request("GET", "/x")
+        assert result == {"ok": True}
+        assert slp.call_args.args[0] == 1  # 2 ** attempt(0)
+
     def test_http_error_returns_message(self):
         tool = HubSpotTool(access_token="x")
         with patch(
@@ -112,8 +128,10 @@ class TestDeals:
         with patch("requests.request", return_value=_mock_response({"ok": True})) as req:
             tool.associate_deal_with_contact(deal_id="2", contact_id="1")
         url = req.call_args.args[1]
-        assert "/deals/2/associations/contacts/1" in url
-        assert req.call_args.kwargs["json"][0]["associationTypeId"] == 3
+        # v3 individual-association endpoint carries the type id in the URL path,
+        # not the request body.
+        assert url.endswith("/deals/2/associations/contacts/1/3")
+        assert req.call_args.kwargs["json"] is None
 
 
 # ── Activities use v3 CRM objects (not legacy /engagements/v1) ───────
@@ -126,6 +144,16 @@ class TestActivities:
         body = req.call_args.kwargs["json"]
         assert body["properties"]["hs_call_body"] == "Discovery call"
         assert body["associations"][0]["to"]["id"] == "1"
+
+    def test_log_meeting_duration_sets_end_time(self):
+        tool = HubSpotTool(access_token="x")
+        with patch("requests.request", return_value=_mock_response({"id": "9"})) as req:
+            tool.log_meeting(
+                contact_id="1", title="Sync", start_time="1000", duration_ms=1800000
+            )
+        props = req.call_args.kwargs["json"]["properties"]
+        assert props["hs_meeting_start_time"] == 1000
+        assert props["hs_meeting_end_time"] == 1000 + 1800000
 
     def test_create_note_associates_multiple_objects(self):
         tool = HubSpotTool(access_token="x")


### PR DESCRIPTION
Fixes #36

## Summary
Adds `HubSpotTool` — a HubSpot CRM integration for PraisonAI agents covering contacts, companies, deals, pipelines, activity logging, unified search, and properties, via the HubSpot REST API v3.

Follows existing tool conventions (`BaseTool`, lazy optional dep, `run()` dispatcher, standalone helper functions, auto-discovery — no `__init__.py` edits needed).

### Implemented
- **Contacts:** create / get / update / search / delete / list (cursor pagination)
- **Companies:** create / get / update / search / associate to contact
- **Deals:** create / get / update / move stage / list / associate with contact & company
- **Pipelines:** list pipelines / get stages
- **Activities:** log call / email / meeting / create note / list activities
- **Search:** unified `search_crm` across contacts, companies, deals
- **Properties:** list / create custom property
- 5 standalone `hubspot_*` tool functions
- `hubspot` optional extra in `pyproject.toml`

### Security / robustness
- Clear error when `HUBSPOT_ACCESS_TOKEN` missing
- Access token **masked** in all error messages
- HTTP 429 retry with exponential backoff (honours `Retry-After`)

### Reviewer feedback (@m13v) incorporated
- Activities use **v3 CRM objects** (`/crm/v3/objects/calls|emails|meetings|notes`) with proper associations — not legacy `/engagements/v1` — so the timeline links to v3 contacts.
- `create_contact` / `create_deal` return the created id directly; no read-after-write re-search that hits HubSpot's search indexing lag (avoids duplicate creation).

## Test plan
- [x] 22 unit tests with mocked HubSpot API (`tests/unit/tools/test_hubspot_tool.py`)
- [x] Auto-discovery: `from praisonai_tools import HubSpotTool` + standalone fns import cleanly
- [x] Discovery / catalogue tests pass

Generated with [Claude Code](https://claude.ai/code)